### PR TITLE
Update README with Kotlin Gradle code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ and integrate them into their SaaS portals in up to 5 lines of code.
       }
   }
   ```
+  ```kotlin
+  android {
+      defaultConfig {
+          minSdk = 26
+      }
+  }
+  ```
 - Java 8+
   Set target java 8 byte code for Android and Kotlin plugins respectively build.gradle:
   ```groovy
@@ -52,7 +59,18 @@ and integrate them into their SaaS portals in up to 5 lines of code.
       }
   }
   ```
-
+  ```kotlin
+    android {
+      compileOptions {
+          sourceCompatibility = JavaVersion.VERSION_1_8
+       	targetCompatibility = JavaVersion.VERSION_1_8
+		}
+  
+      kotlinOptions {
+          jvmTarget = "1.8"
+      }
+  	}
+  ```
 ### Prepare Frontegg workspace
 
 Navigate to [Frontegg Portal Settings](https://portal.frontegg.com/development/settings), If you
@@ -82,7 +100,15 @@ from [Frontegg Portal Domain](https://portal.frontegg.com/development/settings/d
 ```groovy
     dependencies {
     // Add the Frontegg Android Kotlin SDK
-    implementation 'com.frontegg.sdk:android:1.+'
+    implementation 'com.frontegg.sdk:android:LATEST_VERSION'
+    // Add Frontegg observables dependency
+    implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
+}
+```
+```kotlin
+    dependencies {
+    // Add the Frontegg Android Kotlin SDK
+    implementation ("com.frontegg.sdk:android:LATEST_VERSION")
     // Add Frontegg observables dependency
     implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
 }
@@ -90,14 +116,22 @@ from [Frontegg Portal Domain](https://portal.frontegg.com/development/settings/d
 
 ### Set minimum sdk version
 
-To set up your Android minimum sdk version, open root gradle file at`android/build.gradle`,
+To set up your Android minimum sdk version, open the root gradle file at`android/build.gradle`,
 and add/edit the `minSdkVersion` under `buildscript.ext`:
 
 ```groovy
 buildscript {
     ext {
-        minSdkVersion = 26
+        minSdk = 26
         // ...
+    }
+}
+```
+```kotlin
+android {
+    defaultConfig {
+       minSdk = 26
+       // ...
     }
 }
 ```
@@ -131,10 +165,36 @@ android {
 }
 ```
 
+```kotlin
+
+val fronteggDomain = "FRONTEGG_DOMAIN_HOST.com" // without protocol https://
+val fronteggClientId = "FRONTEGG_CLIENT_ID"
+
+android {
+    defaultConfig {
+
+        manifestPlaceholders["package_name"] = applicationId.toString()
+        manifestPlaceholders["frontegg_domain"] = fronteggDomain
+        manifestPlaceholders["frontegg_client_id"] = fronteggClientId
+
+        buildConfigField("String", "FRONTEGG_DOMAIN", "\"$fronteggDomain\"")
+        buildConfigField("String", "FRONTEGG_CLIENT_ID", "\"$fronteggClientId\"")
+    }
+
+}
+```
+
 Add bundleConfig=true if not exists inside the android section inside the app
 gradle `android/app/build.gradle`
 
 ```groovy
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}
+```
+```kotlin
 android {
     buildFeatures {
         buildConfig = true
@@ -302,6 +362,14 @@ android {
     buildConfigField "String", 'FRONTEGG_APPLICATION_ID', "\"$fronteggApplicationId\""
 }
 ```
+```kotlin
+val fronteggApplicationId = "your-application-id-uuid"
+...
+android {
+    ...
+    buildConfigField("String", "FRONTEGG_APPLICATION_ID", "\"$fronteggApplicationId\"")
+}
+```
 
 ### Step 2: Modify the App File
 
@@ -345,6 +413,15 @@ android {
     //  buildConfigField "String", 'FRONTEGG_CLIENT_ID', "\"$fronteggClientId\""
 }
 ```
+```kotlin
+
+android {
+    //  remove this lines:
+    //  buildConfigField("String", "FRONTEGG_DOMAIN", "\"$fronteggDomain\"")
+    //  buildConfigField("String", "FRONTEGG_CLIENT_ID", "\"$fronteggClientId\"")
+}
+```
+
 
 ### Step 2: Modify the App File
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ and integrate them into their SaaS portals in up to 5 lines of code.
 
 - Android SDK 26+
   Set defaultConfig's minSDK to 26+ in build.gradle:
+  
+Groovy:
+  
   ```groovy
   android {
       defaultConfig {
@@ -38,6 +41,9 @@ and integrate them into their SaaS portals in up to 5 lines of code.
       }
   }
   ```
+  
+Kotlin:
+  
   ```kotlin
   android {
       defaultConfig {
@@ -47,6 +53,9 @@ and integrate them into their SaaS portals in up to 5 lines of code.
   ```
 - Java 8+
   Set target java 8 byte code for Android and Kotlin plugins respectively build.gradle:
+  
+Groovy:
+  
   ```groovy
   android {
       compileOptions {
@@ -59,6 +68,8 @@ and integrate them into their SaaS portals in up to 5 lines of code.
       }
   }
   ```
+Kotlin:
+  
   ```kotlin
     android {
       compileOptions {
@@ -97,6 +108,8 @@ from [Frontegg Portal Domain](https://portal.frontegg.com/development/settings/d
 - Find your app's build.gradle file
 - Add the following to your dependencies section:
 
+Groovy:
+
 ```groovy
     dependencies {
     // Add the Frontegg Android Kotlin SDK
@@ -105,6 +118,9 @@ from [Frontegg Portal Domain](https://portal.frontegg.com/development/settings/d
     implementation 'io.reactivex.rxjava3:rxkotlin:3.0.1'
 }
 ```
+
+Kotlin:
+  
 ```kotlin
     dependencies {
     // Add the Frontegg Android Kotlin SDK
@@ -119,6 +135,8 @@ from [Frontegg Portal Domain](https://portal.frontegg.com/development/settings/d
 To set up your Android minimum sdk version, open the root gradle file at`android/build.gradle`,
 and add/edit the `minSdkVersion` under `buildscript.ext`:
 
+Groovy:
+
 ```groovy
 buildscript {
     ext {
@@ -127,6 +145,9 @@ buildscript {
     }
 }
 ```
+
+Kotlin:
+
 ```kotlin
 android {
     defaultConfig {
@@ -142,6 +163,8 @@ To set up your Android application on to communicate with Frontegg, you have to
 add `buildConfigField` property the
 gradle `android/app/build.gradle`.
 This property will store frontegg hostname (without https) and client id from previous step:
+
+Groovy:
 
 ```groovy
 
@@ -165,6 +188,8 @@ android {
 }
 ```
 
+Kotlin:
+
 ```kotlin
 
 val fronteggDomain = "FRONTEGG_DOMAIN_HOST.com" // without protocol https://
@@ -187,6 +212,8 @@ android {
 Add bundleConfig=true if not exists inside the android section inside the app
 gradle `android/app/build.gradle`
 
+Groovy:
+
 ```groovy
 android {
     buildFeatures {
@@ -194,6 +221,9 @@ android {
     }
 }
 ```
+
+Kotlin:
+
 ```kotlin
 android {
     buildFeatures {
@@ -354,6 +384,8 @@ This guide outlines the steps to configure your Android application to support m
 
 Add `FRONTEGG_APPLICATION_ID` buildConfigField into the `build.gradle` file:
 
+Groovy:
+
 ```groovy
 def fronteggApplicationId = "your-application-id-uuid"
 ...
@@ -362,6 +394,9 @@ android {
     buildConfigField "String", 'FRONTEGG_APPLICATION_ID', "\"$fronteggApplicationId\""
 }
 ```
+
+Kotlin:
+
 ```kotlin
 val fronteggApplicationId = "your-application-id-uuid"
 ...
@@ -405,6 +440,8 @@ This guide outlines the steps to configure your Android application to support m
 
 First, remove buildConfigFields from your `build.gradle` file:
 
+Groovy:
+
 ```groovy
 
 android {
@@ -413,6 +450,9 @@ android {
     //  buildConfigField "String", 'FRONTEGG_CLIENT_ID', "\"$fronteggClientId\""
 }
 ```
+
+Kotlin:
+
 ```kotlin
 
 android {
@@ -597,7 +637,22 @@ android.defaults.buildfeatures.buildconfig=true
 ```
 
 2. Add the below lines to your app/`build.gradle`:
+
+Groovy:
+
 ```gradle
+android {
+    ...
+    buildFeatures {
+        buildConfig = true
+    }
+    ...
+}
+```
+
+Kotlin:
+
+```kotlin
 android {
     ...
     buildFeatures {


### PR DESCRIPTION
More and more Android developers are using Kotlin for their Gradle files. As a reminder, Kotlin versions of Gradle files are the Gradle files that end in`.kts` 

<img width="214" alt="Screenshot 2024-10-07 at 12 47 30 PM" src="https://github.com/user-attachments/assets/e7173bc8-ba55-44f8-9187-f7ef6ab40047">

If you start a new project in Android Studio these days, it creates Kotlin-based Gradle files ☝🏽  

All of the Gradle-related code blocks in the Front Egg Android SDK docs are Groovy only 😢  It'd be helpful if the Android docs would have Kotlin code blocks. This pr adds those code blocks that are equivalent to the Groovy ones.

My assumption is that the docs at https://docs.frontegg.com/docs/android-kotlin come from this repo's README file. If that's not the case, then let's at least have this pr update the SDK repo's README **and** then you all can use the pr's new Kotlin code blocks to update the Android docs in whatever way you update the docs.

Thanks