### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Groovy:
 ```groovy
 
 android {
-    //  remove this lines:
+    //  remove these lines:
     //  buildConfigField "String", 'FRONTEGG_DOMAIN', "\"$fronteggDomain\""
     //  buildConfigField "String", 'FRONTEGG_CLIENT_ID', "\"$fronteggClientId\""
 }
@@ -461,7 +461,7 @@ Kotlin:
 ```kotlin
 
 android {
-    //  remove this lines:
+    //  remove these lines:
     //  buildConfigField("String", "FRONTEGG_DOMAIN", "\"$fronteggDomain\"")
     //  buildConfigField("String", "FRONTEGG_CLIENT_ID", "\"$fronteggClientId\"")
 }


### PR DESCRIPTION
This pr fixes a typo in the README as a follow up to my https://github.com/frontegg/frontegg-android-kotlin/pull/78 pr