### PR TITLE
remove permission section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,16 +232,6 @@ android {
 }
 ```
 
-### Permissions
-
-Add `INTERNET` permission to the app's manifest file.
-
-```xml
-
-<uses-permission android:name="android.permission.INTERNET"/>
-<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
-```
-
 ### Initialize FronteggApp
 
 Create a custom `App` class that extends `android.app.Application` to initialize `FronteggApp`:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-
     <application
         android:name=".App"
         android:allowBackup="true"


### PR DESCRIPTION
These permissions are already added  to the manifest file in the library module. So, we don't need to add them to the manifest of the application we are integrating the library into.
Because when we build our application, all the manifests are merged into one, so we will have one file with all the permissions.
Another point about the permission - android.permission.POST_NOTIFICATIONS - is whether we really need it, because I may not know or remember something, but I didn't see in the code what functionality we need it for.