### PR TITLE
Add basic docs about actually using the SDK after logging in

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and integrate them into their SaaS portals in up to 5 lines of code.
     - [Setup for `Gradle8+`](#setup-for--gradle8)
 - [Usage](#usage)
     - [Login with Frontegg](#login-with-frontegg)
+    - [Using the SDK](#using-the-sdk)
     - [Logout user](#logout)
     - [Switch Tenant](#switch-tenant)
 
@@ -725,6 +726,29 @@ class FirstFragment : Fragment() {
 }
 
 ```
+
+## Using the SDK
+
+Once the log in process is complete, the SDK will bring your user back to wherever you started the log in process.
+
+At this point, you'll keep using `FronteggAuth.instance` to actually interact with the SDK and get to information you might care about. The instance gives you access to different Rx `ObservableValue` values for use in your project. For example:
+
+- Get the `User` object to get info such as name, email, ID, phone number, or profile picture URL.
+
+```kotlin
+FronteggAuth.instance.user
+
+FronteggAuth.instance.user.value?.email
+
+FronteggAuth.instance.user.value?.name
+```
+
+- Check whether the user is authenticated and "signed in".
+
+```kotlin
+FronteggAuth.instance.isAuthenticated.value
+```
+
 
 ## Logout user
 


### PR DESCRIPTION
This pr adds very basic docs about actually using the SDK after logging in. 
I'm surprised that this type of info doesn't already exist on https://docs.frontegg.com/docs/android-kotlin 😕 All of the current sections in https://docs.frontegg.com/docs/android-kotlin are about how to set up the SDK, how to log in, and how to log out. 

However, there's no advice on how to actually _use_ the SDK on a day-to-day basis as an Android developer trying to get started with the SDK and implementing it throughout an Android project. 


- I searched elsewhere in the Frontegg docs world, but didn’t find any Android content in:

  - https://support.frontegg.com/hc/en-us/search?utf8=%E2%9C%93&query=android+sdk
  - https://github.com/frontegg-samples?q=java&type=all&language=&sort=
  - https://github.com/frontegg-samples?q=kotlin&type=all&language=&sort=
  - https://github.com/frontegg-samples?q=android&type=all&language=&sort=

- Maybe there’s Android talk within the Frontegg Slack community, but I shouldn’t have to sign up for a new Slack workspace to just discover this basic info.

- Because `frontegg-samples` (https://github.com/frontegg-samples) is set up as a completely different Github organization than `frontegg`, there’s no easy way to discover the other one if you’re currently browsing among one of them on Github.

Without lots of exploration and dumb luck, there's no way I would've quickly known how to get the user's name, email, etc. Android developers implementing the SDK should quickly and easily know that this information 👇🏽  exists in the SDK:
<img width="764" alt="Screenshot 2024-10-18 at 12 38 05 PM" src="https://github.com/user-attachments/assets/dc2aba6b-c6d2-4100-ba4c-10fef31a625d">


**If the Frontegg team isn't happy with these docs, then I'd request that they provide edits and/or add their own similar docs.**