### PR TITLE
fix refresh in background

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAppService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAppService.kt
@@ -43,6 +43,10 @@ class FronteggAppService(
             )
     }
 
+    fun isAppInForeground(): Boolean {
+        return appLifecycle.appInForeground
+    }
+
     private fun fillStorage() {
         storage.fill(
             baseUrl,

--- a/android/src/main/java/com/frontegg/android/services/RefreshTokenJobService.kt
+++ b/android/src/main/java/com/frontegg/android/services/RefreshTokenJobService.kt
@@ -7,13 +7,22 @@ import android.util.Log
 import androidx.annotation.VisibleForTesting
 import java.net.SocketTimeoutException
 import java.time.Instant
+import com.frontegg.android.FronteggApp
 
 class RefreshTokenJobService : JobService() {
     companion object {
         private val TAG = RefreshTokenJobService::class.java.simpleName
-    }
+    }   
 
     override fun onStartJob(params: JobParameters?): Boolean {
+        val appService = FronteggApp.getInstance() as? FronteggAppService
+        
+        if (appService == null || !appService.isAppInForeground()) {
+            Log.d(TAG, "Application is not in the foreground, skipping token refresh")
+            jobFinished(params, false)
+            return false
+        }
+        
         Log.d(
             TAG,
             "Job started, (${


### PR DESCRIPTION
- added a check — if the application isn't running, just skip the refresh since we refresh it anyway after the application start