### PR TITLE
fix(sdk): preserve session on transient probe failure during init

### DIFF
--- a/.github/scripts/generate_e2e_matrix.js
+++ b/.github/scripts/generate_e2e_matrix.js
@@ -60,6 +60,7 @@ const TEST_WEIGHTS = {
   testLogoutTerminateTransientNoConnectionThenCustomSSORecovers: 72,
   testScheduledTokenRefreshFiresBeforeExpiry: 68,
   testExpiredAccessTokenRefreshesOnAuthenticatedRelaunch: 62,
+  testAuthenticatedColdStartWithExpiredAccessTokenAndTransientProbeFailurePreservesSession: 62,
   testAuthenticatedRelaunchWithExpiredAccessTokenAndFreshRefreshToken: 60,
   testAuthenticatedOfflineModeKeepsUserLoggedInUntilReconnectRefreshesExpiredToken: 58,
   testPasswordLoginAndSessionRestore: 52,
@@ -117,6 +118,7 @@ const SOLO_SHARD_METHODS = new Set([
   "testAuthenticatedOfflineModeRecoversToOnlineAndRefreshesToken",
   "testAuthenticatedOfflineModeKeepsUserLoggedInUntilReconnectRefreshesExpiredToken",
   "testOfflineModeDisabledPreservesSessionDuringConnectionLossAndRecovers",
+  "testAuthenticatedColdStartWithExpiredAccessTokenAndTransientProbeFailurePreservesSession",
 ]);
 
 /**

--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -1263,17 +1263,20 @@ class FronteggAuthService(
                 // Check network quality before attempting any network operations
                 if (!isNetworkGoodSync()) {
                     Log.w(TAG, "Network quality is poor during initialization, keeping tokens")
+                    // A transient probe failure (e.g., FCM cold start while the radio is
+                    // resuming from doze) is not an auth failure. Keep the cached session
+                    // optimistically — a real auth failure will be surfaced when the next
+                    // /me or /oauth/token call returns 401, not by a 5-second probe.
+                    this@FronteggAuthService.isAuthenticated.value = true
                     if (enableOfflineMode) {
-                        this@FronteggAuthService.isAuthenticated.value = true
                         credentialManager.getOfflineUser()?.let { this@FronteggAuthService.user.value = it }
                         this@FronteggAuthService.setOfflineMode(true)
                         this@FronteggAuthService.isLoading.value = true
                         initializing.value = false
                         startUserDataMonitoring()
                     } else {
-                        clearCredentials()
-                        initializing.value = false
                         isLoading.value = false
+                        initializing.value = false
                     }
                     return@launch
                 }

--- a/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
@@ -730,4 +730,57 @@ class FronteggAuthServiceTest {
         auth.stepUp(mockActivity, duration, null)
         coVerify { stepUpAuthenticator.stepUp(any(), any(), any()) }
     }
+
+    @Test
+    fun `initializeSubscriptions preserves session when network probe transiently fails on cold start`() = runBlocking {
+        // Reproduces customer-reported bug: app backgrounded 5+ hours, FCM cold-start triggers
+        // initializeSubscriptions while the radio is still resuming from doze. The synchronous
+        // network-quality probe (HEAD /<base>/test) returns false for ~one cycle, even though
+        // the device is online and the refresh token is valid.
+        //
+        // With enableOfflineMode = false (default), FronteggAuthService.kt:1216-1230 currently
+        // calls clearCredentials() on a single failed probe — wiping a perfectly good session.
+        //
+        // Expected (post-fix): a transient probe failure must NOT destroy the session. Tokens
+        // remain on disk and in memory; the SDK proceeds to /me / refresh validation.
+        // This test currently FAILS and is the reproduction for the bug.
+
+        // Logged-in state: tokens were persisted on disk by a previous successful login.
+        every { credentialManagerMock.get(CredentialKeys.ACCESS_TOKEN, null) } returns "saved-access-token"
+        every { credentialManagerMock.get(CredentialKeys.REFRESH_TOKEN, null) } returns "saved-refresh-token"
+        every { credentialManagerMock.clear() } returns Unit
+        every { credentialManagerMock.clear(any()) } returns Unit
+        every { credentialManagerMock.clearOfflineUser() } returns true
+        every { credentialManagerMock.getOfflineUser() } returns null
+        every { credentialManagerMock.saveLastTenantIdForUser(any(), any()) } returns true
+        every { credentialManagerMock.setCurrentTenantId(any()) } returns true
+        every { credentialManagerMock.save(any(), any()) } returns true
+        every { credentialManagerMock.save(any(), any(), any()) } returns true
+
+        // The trigger: probe returns false (cached radio state during wake-from-doze).
+        every { NetworkGate.isNetworkLikelyGood(any()) } returns false
+
+        // The actual /me call would succeed if the SDK didn't short-circuit on the probe.
+        val user = User()
+        every { apiMock.me() } returns user
+        mockkObject(JWTHelper)
+        val jwt = JWT()
+        jwt.exp = (System.currentTimeMillis() / 1000) + 3600
+        every { JWTHelper.decode(any()) } returns jwt
+
+        auth.initializeSubscriptions()
+        delay(300) // bgScope.launch on Dispatchers.Unconfined; small slack for safety
+
+        // Post-fix expectations: session is preserved, credentials NOT wiped.
+        assert(auth.accessToken.value == "saved-access-token") {
+            "Access token should remain in memory after a transient probe failure, was ${auth.accessToken.value}"
+        }
+        assert(auth.refreshToken.value == "saved-refresh-token") {
+            "Refresh token should remain in memory after a transient probe failure, was ${auth.refreshToken.value}"
+        }
+        assert(auth.isAuthenticated.value) {
+            "isAuthenticated should remain true on a transient probe failure with valid stored tokens — currently flips to false because clearCredentials() is called"
+        }
+        verify(exactly = 0) { credentialManagerMock.clear(any()) }
+    }
 }

--- a/embedded/e2e/scenario-catalog.json
+++ b/embedded/e2e/scenario-catalog.json
@@ -81,6 +81,11 @@
       "description": "Launches with enableOfflineMode=false and completes a password login, confirming normal auth flows are unaffected."
     },
     {
+      "method": "testAuthenticatedColdStartWithExpiredAccessTokenAndTransientProbeFailurePreservesSession",
+      "title": "Cold start with expired access token and transient probe failure preserves session",
+      "description": "Logs in with enableOfflineMode=false, terminates, waits past access-token expiry, queues a single probe failure, and relaunches — verifies the session is preserved instead of being wiped by the network gate (regression test for the FCM-cold-start bug)."
+    },
+    {
       "method": "testLogoutClearsSessionAndRelaunchShowsLogin",
       "title": "Logout clears session so relaunch shows login",
       "description": "Logs in, logs out, terminates, relaunches without reset, and verifies the login page appears (keychain cleared by logout)."

--- a/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETests.kt
+++ b/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETests.kt
@@ -243,6 +243,43 @@ class EmbeddedE2ETests : EmbeddedE2ETestCase() {
     }
 
     @Test
+    fun testAuthenticatedColdStartWithExpiredAccessTokenAndTransientProbeFailurePreservesSession() {
+        // Reproduces customer report: app backgrounded 5+ hours → FCM push wakes the
+        // process → user lands on login screen instead of authenticated state.
+        //
+        // FCM-triggered cold starts often fire while the radio is resuming from doze, so
+        // the SDK's network-quality probe (HEAD /<base>/test) can transiently fail even
+        // though the device is online and the refresh token is valid.
+        //
+        // With enableOfflineMode = false (the default), the network-gate branch at
+        // FronteggAuthService.kt:1216-1230 currently calls clearCredentials() on a single
+        // failed probe — wiping a perfectly good session. This test asserts the opposite:
+        // a transient probe failure must NOT destroy the session; the SDK should proceed
+        // to refresh-token validation and keep the user authenticated.
+        //
+        // Expected to fail until the bug at FronteggAuthService.kt:1226 is fixed.
+        mock.configureTokenPolicy(
+            email = "test@frontegg.com",
+            accessTTL = expiringAccessTokenTTL,
+            refreshTTL = longLivedRefreshTokenTTL,
+        )
+        launchApp(resetState = true, enableOfflineMode = false)
+        loginWithPassword()
+        waitForUserEmail("test@frontegg.com", timeoutMs = 120_000)
+        terminateApp()
+        // Simulate the long background: access token expires before relaunch.
+        waitDurationSeconds((expiringAccessTokenTTL + 14).toLong())
+        // Simulate the FCM-wake-from-doze condition: the first network-quality probe
+        // after relaunch returns 503. Subsequent probes will succeed (only one queued).
+        mock.queueProbeFailures(listOf(503))
+        launchApp(resetState = false, enableOfflineMode = false)
+        dismissBrowserForegroundIfNeeded()
+        instrumentation.waitForIdleSync()
+        // Today: lands on LoginPageRoot. After fix: must stay authenticated.
+        waitForUserEmail("test@frontegg.com", timeoutMs = 300_000)
+    }
+
+    @Test
     fun testPasswordLoginWorksWithOfflineModeDisabled() {
         launchApp(resetState = true, enableOfflineMode = false)
         waitForDesc("LoginPageRoot", 120_000)


### PR DESCRIPTION
## Summary

- A failed network-quality probe during `initializeSubscriptions()` was being treated as an auth failure when `enableOfflineMode` is disabled (the default), calling `clearCredentials()` and wiping a perfectly valid session.
- Most visible on FCM-driven cold starts after long backgrounds: the radio is still resuming from doze, the 5-second HEAD probe to `/<base>/test` returns a stale negative, and the user lands on the login screen even though the refresh token is still valid.
- Apply the same pattern as [86a5793](https://github.com/frontegg/frontegg-android-kotlin/commit/86a5793) (transient 5xx during refresh): keep cached tokens, mark the user authenticated, let the next `/me` or `/oauth/token` call surface a real 401 if the user was actually logged out server-side. A 5s HEAD probe is a hint, not auth state.

## Reproduction

Confirmed by a unit test that drives `initializeSubscriptions()` directly with persisted tokens + forced probe failure + `enableOfflineMode = false`. Before the fix, the test failed at:

```
java.lang.AssertionError: Access token should remain in memory
after a transient probe failure, was null
```

Proving `clearCredentials()` had wiped the in-memory session. After the fix the test passes.

## Test plan

- [x] New unit test `FronteggAuthServiceTest.initializeSubscriptions preserves session when network probe transiently fails on cold start` — passes with the fix, fails on `master`
- [x] Full `:android:testDebugUnitTest` suite green
- [x] Full `FronteggAuthServiceTest`, `FronteggAuthServiceExtendedTest`, `FronteggAppServiceTest` suites green
- [ ] New E2E test `EmbeddedE2ETests.testAuthenticatedColdStartWithExpiredAccessTokenAndTransientProbeFailurePreservesSession` — runs via the existing emulator CI matrix
- [ ] Existing E2E tests covering `enableOfflineMode = false` paths (`testColdLaunchWithOfflineModeDisabledReachesLoginQuickly`, `testOfflineModeDisabledPreservesSessionDuringConnectionLossAndRecovers`, `testPasswordLoginWorksWithOfflineModeDisabled`) still pass

## Behaviour matrix

| Scenario | `enableOfflineMode` | Before | After |
|---|---|---|---|
| Cold start, no tokens, probe fails | any | login screen | login screen (unchanged) |
| Cold start, valid tokens, probe fails | `true` | offline mode + authed | offline mode + authed (unchanged) |
| Cold start, valid tokens, probe fails | `false` | **`clearCredentials()` → login screen** | authed; next `/me` decides |
| `/oauth/token` returns 5xx during refresh | any | authed (since 86a5793) | authed (unchanged) |
| `/oauth/token` returns 401 (real server logout) | any | login screen | login screen (unchanged) |