### PR TITLE
fix(sdk): trust server tenant on fresh login instead of stale cache (FR-24632)

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -137,14 +137,6 @@ class FronteggAuthService(
         }
     }
 
-    private fun getCachedTenantIdForUser(user: User): String? {
-        return try {
-            credentialManager.getLastTenantIdForUser(user.id)
-        } catch (_: Exception) {
-            null
-        }
-    }
-    
     private val multiFactorAuthenticator =
         MultiFactorAuthenticatorProvider.getMultiFactorAuthenticator()
     private val stepUpAuthenticator =
@@ -770,19 +762,17 @@ class FronteggAuthService(
 
                 if (enableSessionPerTenant) {
                     val serverTenantId = user.activeTenant.tenantId
-                    val cachedTenantId = getCachedTenantIdForUser(user)
-                    val cachedTenantValid =
-                        !cachedTenantId.isNullOrBlank() && user.tenants.any { it.tenantId == cachedTenantId }
+                    // Trust the server's active tenant on a fresh login (initialTenantId == null).
+                    // The per-user "last tenant" cache used to override server here, but that yanked
+                    // users back to a stale tenant after logout-then-relogin under a different
+                    // tenant — see FR-24632. The cache is still written below for diagnostic/host-app
+                    // use; callers who want "remember last tenant" should re-issue switchTenant.
+                    val desiredTenantId = initialTenantId ?: serverTenantId
 
-                    val desiredTenantId = when {
-                        initialTenantId != null -> initialTenantId
-                        cachedTenantValid -> cachedTenantId
-                        else -> serverTenantId
-                    }
-
-                    if (!desiredTenantId.isNullOrBlank() && desiredTenantId != serverTenantId) {
+                    if (desiredTenantId.isNotBlank() && desiredTenantId != serverTenantId) {
                         try {
-                            // Align server-side active tenant to the cached tenant for this user/device.
+                            // initialTenantId differs from server (e.g. mid-session token refresh
+                            // for the user's currently-selected tenant). Realign server-side.
                             api.switchTenant(desiredTenantId)
 
                             // Tokens are tenant-dependent; refresh to get tokens for the desired tenant.
@@ -800,7 +790,7 @@ class FronteggAuthService(
                         }
                     }
 
-                    val finalTenantId = desiredTenantId ?: user.activeTenant.tenantId
+                    val finalTenantId = desiredTenantId.ifBlank { user.activeTenant.tenantId }
                     credentialManager.setCurrentTenantId(finalTenantId)
                     credentialManager.save(CredentialKeys.REFRESH_TOKEN, finalRefreshToken, finalTenantId)
                     credentialManager.save(CredentialKeys.ACCESS_TOKEN, finalAccessToken, finalTenantId)
@@ -861,19 +851,17 @@ class FronteggAuthService(
 
                 if (enableSessionPerTenant) {
                     val serverTenantId = user.activeTenant.tenantId
-                    val cachedTenantId = getCachedTenantIdForUser(user)
-                    val cachedTenantValid =
-                        !cachedTenantId.isNullOrBlank() && user.tenants.any { it.tenantId == cachedTenantId }
+                    // Trust the server's active tenant on a fresh login (initialTenantId == null).
+                    // The per-user "last tenant" cache used to override server here, but that yanked
+                    // users back to a stale tenant after logout-then-relogin under a different
+                    // tenant — see FR-24632. The cache is still written below for diagnostic/host-app
+                    // use; callers who want "remember last tenant" should re-issue switchTenant.
+                    val desiredTenantId = initialTenantId ?: serverTenantId
 
-                    val desiredTenantId = when {
-                        initialTenantId != null -> initialTenantId
-                        cachedTenantValid -> cachedTenantId
-                        else -> serverTenantId
-                    }
-
-                    if (!desiredTenantId.isNullOrBlank() && desiredTenantId != serverTenantId) {
+                    if (desiredTenantId.isNotBlank() && desiredTenantId != serverTenantId) {
                         try {
-                            // Align server-side active tenant to the cached tenant for this user/device.
+                            // initialTenantId differs from server (e.g. mid-session token refresh
+                            // for the user's currently-selected tenant). Realign server-side.
                             api.switchTenant(desiredTenantId)
 
                             // Tokens are tenant-dependent; refresh to get tokens for the desired tenant.
@@ -891,7 +879,7 @@ class FronteggAuthService(
                         }
                     }
 
-                    val finalTenantId = desiredTenantId ?: user.activeTenant.tenantId
+                    val finalTenantId = desiredTenantId.ifBlank { user.activeTenant.tenantId }
                     credentialManager.setCurrentTenantId(finalTenantId)
                     credentialManager.save(CredentialKeys.REFRESH_TOKEN, finalRefreshToken, finalTenantId)
                     credentialManager.save(CredentialKeys.ACCESS_TOKEN, finalAccessToken, finalTenantId)

--- a/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
@@ -14,6 +14,7 @@ import com.frontegg.android.EmbeddedAuthActivity
 import com.frontegg.android.FronteggApp
 import com.frontegg.android.embedded.CredentialManagerHandler
 import com.frontegg.android.models.AuthResponse
+import com.frontegg.android.models.Tenant
 import com.frontegg.android.models.User
 import com.frontegg.android.models.WebAuthnAssertionRequest
 import com.frontegg.android.models.WebAuthnRegistrationRequest
@@ -782,5 +783,71 @@ class FronteggAuthServiceTest {
             "isAuthenticated should remain true on a transient probe failure with valid stored tokens — currently flips to false because clearCredentials() is called"
         }
         verify(exactly = 0) { credentialManagerMock.clear(any()) }
+    }
+
+    @Test
+    fun `setCredentials does not reconcile to cached per-user tenant on fresh post-logout login`() {
+        // FR-24632: same human / same user.id with memberships in tenants A and B.
+        // Customer logs in under A, logs out, logs back in under B (e.g. via
+        // organization param or a tenant-specific login URL). After logout,
+        // last_tenant_id_user_<id> is intentionally preserved on disk
+        // (CredentialManager.kt:152-167). Pre-fix, setCredentials's reconciliation
+        // (FronteggAuthService.kt:773-801) saw initialTenantId=null + cachedTenantId=A
+        // valid for the user, picked A as desiredTenantId, and called
+        // api.switchTenant(A) + api.refreshToken — pinning state back to A even
+        // though the user just logged in under B. The customer's app then called
+        // switchTenant(B) to correct, which fell through to refreshIdempotent and
+        // hit the v1.3.23 skip-if-not-expired guard, so state stayed on A until
+        // the access token expired (~45s) and auto-refresh fired.
+        //
+        // Expected (post-fix): a fresh login lands on the server's active tenant.
+        // The "remember last tenant" cache is appropriate for cold-start with
+        // persisted tokens (handled by initialTenantId != null), not for fresh
+        // post-logout logins where the user has just made an explicit choice.
+
+        every { storageMock.enableSessionPerTenant }.returns(true)
+
+        // Post-logout state: in-memory tokens cleared, currentTenantId cleared,
+        // but per-user "last tenant" preserved (== "tenant-A").
+        every { credentialManagerMock.getCurrentTenantId() }.returns(null) andThen "tenant-B"
+        every { credentialManagerMock.getLastTenantIdForUser("user-1") }.returns("tenant-A")
+        every { credentialManagerMock.setCurrentTenantId(any()) }.returns(true)
+        every { credentialManagerMock.saveLastTenantIdForUser(any(), any()) }.returns(true)
+        every { credentialManagerMock.save(any(), any()) }.returns(true)
+        every { credentialManagerMock.save(any(), any(), any()) }.returns(true)
+
+        // The user just logged in under tenant-B; the server confirms that.
+        val tenantA = Tenant().apply { id = "tenant-A"; tenantId = "tenant-A" }
+        val tenantB = Tenant().apply { id = "tenant-B"; tenantId = "tenant-B" }
+        val user = User().apply {
+            id = "user-1"
+            tenants = listOf(tenantA, tenantB)
+            activeTenant = tenantB
+        }
+        every { apiMock.me() }.returns(user)
+
+        mockkObject(JWTHelper)
+        val jwt = JWT()
+        jwt.exp = (System.currentTimeMillis() / 1000) + 3600
+        every { JWTHelper.decode(any()) }.returns(jwt)
+
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+
+        // Drives setCredentials(access, refresh) through the public surface.
+        auth.updateCredentials("access-token-for-B", "refresh-token-for-B")
+
+        // No spurious reconciliation: the SDK must not yank the user back to the cached tenant.
+        verify(exactly = 0) { apiMock.switchTenant(any()) }
+        verify(exactly = 0) { apiMock.refreshToken(any()) }
+
+        // State reflects the server's active tenant (B), not the cached tenant (A).
+        verify { credentialManagerMock.setCurrentTenantId("tenant-B") }
+        assert(auth.user.value?.activeTenant?.tenantId == "tenant-B") {
+            "user.activeTenant should be tenant-B (server's active tenant), was ${auth.user.value?.activeTenant?.tenantId}"
+        }
+        assert(auth.accessToken.value == "access-token-for-B") {
+            "accessToken.value should be the freshly-minted token for tenant-B, was ${auth.accessToken.value}"
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Drops the per-user "last tenant" cache override from `setCredentials`'s tenant reconciliation. On a fresh login (`initialTenantId == null`) the SDK now trusts the server's active tenant — which reflects the user's choice (organization param, tenant subdomain, or server default) — instead of yanking them back to whatever tenant they used before logout.
- Removes the now-unused `getCachedTenantIdForUser` helper. Cache writes via `cacheLastTenantForUser` are kept for diagnostics / host-app use.
- Adds `setCredentials does not reconcile to cached per-user tenant on fresh post-logout login` to `FronteggAuthServiceTest` as the regression reproduction.

## Why

Customer report ([FR-24632](https://frontegg.atlassian.net/browse/FR-24632)): same `user.id` with memberships in tenants A and B. Log in under A, log out, log in under B — the SDK reported A's credentials for ~45 s before self-healing.

Tracing the bug:
1. `last_tenant_id_user_<id>` is intentionally preserved across logout (`CredentialManager.kt:152-167`).
2. On the new login under B, `setCredentials` saw `initialTenantId == null`, picked `cachedTenantId == "tenant-A"`, and called `api.switchTenant("tenant-A")` + `api.refreshToken` — pinning state back to A even though the user just authenticated under B.
3. The customer's app called `switchTenant(B)` to correct, but its fall-through path hits `refreshIdempotent`'s `skip-if-token-not-expired` guard (added in v1.3.23) and never refreshed, so state stayed on A.
4. ~45 s later (one access-token TTL), the auto-refresh timer fired, which finally fetched tokens for the now-correct server-side tenant B.

Pre-FR-23182 (≤ v1.3.15 / Flutter 1.0.20) had no cache override and didn't exhibit this bug. The customer reported this as a regression between Flutter 1.0.20 and 1.0.41 — that gap straddles v1.3.16 (FR-23182) on the Android side.

## Behaviour change

| Scenario | Before | After |
| --- | --- | --- |
| Fresh login post-logout, server tenant matches cached tenant | Uses server tenant | Same — uses server tenant |
| Fresh login post-logout, server tenant differs from cached tenant (this bug) | Calls `switchTenant(cached)` + `refreshToken`, pins to cached | Uses server tenant |
| Cold start with persisted tokens (`currentTenantId` restored) | `initialTenantId` non-null path — uses persisted tenant | Same — uses persisted tenant |
| Mid-session token refresh / re-login while `user.value` is set | `initialTenantId` non-null — realigns server if needed | Same |

Customers who relied on the SDK silently restoring their previous tenant after a logout/relogin should re-issue `switchTenant(cachedId)` after login (the `last_tenant_id_user_<id>` value is still being written and is queryable via `CredentialManager.getLastTenantIdForUser`).

## Test plan

- [x] New regression test fails on master with `Api(#…).switchTenant(tenant-A)` being invoked
- [x] New regression test passes after the fix
- [x] Full `:android:testDebugUnitTest` suite green
- [ ] E2E suite (rerun on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-24632]: https://frontegg.atlassian.net/browse/FR-24632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ