### PR TITLE
ci: fix CHANGELOG step crashing on PR bodies with apostrophes/parens

### DIFF
--- a/.github/workflows/onPullRequestMerged.yaml
+++ b/.github/workflows/onPullRequestMerged.yaml
@@ -122,6 +122,7 @@ jobs:
       - name: Update CHANGELOG file
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DESCRIPTION: ${{ steps.get_description.outputs.DESCRIPTION }}
         shell: bash
         run: |
           if [[ -f "${{ env.CHANGELOG_FILE }}" ]]; then
@@ -129,15 +130,17 @@ jobs:
           else
             echo "WARNING: CHANGELOG_FILE does not exist!"
           fi
-          
-          
-          # Append PR description to CHANGELOG_FILE safely
+
+
+          # Append PR description to CHANGELOG_FILE safely. The description is
+          # passed via env (which GitHub Actions properly escapes) rather than
+          # interpolated as a literal shell token, so apostrophes/backticks/
+          # parens in the PR body don't break shell quoting.
           if [[ -f "${{ env.CHANGELOG_FILE }}" ]]; then
-            CHANGELOG_FILE_CONTENT="$(cat ${{ env.CHANGELOG_FILE }})"
-            echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
-            echo -e "\n$CHANGELOG_FILE_CONTENT" >> ${{ env.CHANGELOG_FILE }}
+            CHANGELOG_FILE_CONTENT="$(cat "${{ env.CHANGELOG_FILE }}")"
+            printf '%s\n\n%s\n' "$DESCRIPTION" "$CHANGELOG_FILE_CONTENT" > "${{ env.CHANGELOG_FILE }}"
           else
-            echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
+            printf '%s\n' "$DESCRIPTION" > "${{ env.CHANGELOG_FILE }}"
           fi
 
       - name: Commit changes

--- a/.github/workflows/onReleasePullRequestUpdated.yaml
+++ b/.github/workflows/onReleasePullRequestUpdated.yaml
@@ -39,12 +39,16 @@ jobs:
           # Extract the description (body field)
           DESCRIPTION=$(echo "$pr_metadata" | jq -r '.body // ""')
           
-          # Check if DESCRIPTION is valid
+          # Check if DESCRIPTION is valid. Use printf with the variable in
+          # double quotes so apostrophes/backticks/parens in the PR body don't
+          # break shell quoting (the previous single-quoted echo would crash on
+          # any apostrophe in the description).
           if [[ -n "$DESCRIPTION" && "$DESCRIPTION" != "null" ]]; then
             if [[ -f "${{ env.CHANGELOG_OLD_FILE }}" ]]; then
-              echo -e "$DESCRIPTION\n\n$(cat ${{ env.CHANGELOG_OLD_FILE }})" > ${{ env.CHANGELOG_FILE }}
+              OLD_CONTENT="$(cat "${{ env.CHANGELOG_OLD_FILE }}")"
+              printf '%s\n\n%s\n' "$DESCRIPTION" "$OLD_CONTENT" > "${{ env.CHANGELOG_FILE }}"
             else
-              echo '${{ steps.get_description.outputs.DESCRIPTION }}' > ${{ env.CHANGELOG_FILE }}
+              printf '%s\n' "$DESCRIPTION" > "${{ env.CHANGELOG_FILE }}"
             fi
           else
             echo "No description provided in the pull request. The 'release/next' branch must provide a description for correct CHANGELOG.md generation."


### PR DESCRIPTION
## Summary

- Pass the PR description into the CHANGELOG bash step via the step `env:` block instead of literal `${{ ... }}` interpolation, and write it with `printf '%s\n' "$DESCRIPTION"` instead of `echo -e '...'`.
- Apply the same fix to the release-PR variant (`onReleasePullRequestUpdated.yaml`), and while there, fix a latent bug in the no-old-file branch that referenced a non-existent `steps.get_description.outputs.DESCRIPTION` instead of the local `$DESCRIPTION` variable.

## Why

The release-PR job for [#242](https://github.com/frontegg/frontegg-android-kotlin/pull/242) failed at the "Update CHANGELOG file" step with `syntax error near unexpected token '('` (run [25211285757](https://github.com/frontegg/frontegg-android-kotlin/actions/runs/25211285757/job/73922296752)).

Root cause: the step body was literally —

```bash
echo -e '${{ steps.get_description.outputs.DESCRIPTION }}' > ./CHANGELOG.md
```

GitHub Actions substitutes the expression as raw text into the rendered shell script. The PR body for #242 contained apostrophes (`customer's`, `didn't`, `setCredentials's`); the first one closed the single-quoted string, and the next `(FR-24632)` then parsed as a subshell, blowing up the job. Any future PR with a `'`, backtick, or `\` in the description would hit the same crash. This isn't theoretical — the merged release for v1.3.27 silently lost its CHANGELOG entry because of this.

The fix: route the description through the step's `env:` block (Actions handles escaping into the env, not the shell) and write it via `printf '%s\n' "$DESCRIPTION"`. With the variable double-quoted, all of `'`, `(`, backtick, `\` survive untouched.

## Behaviour change

| Scenario | Before | After |
| --- | --- | --- |
| PR body contains apostrophe / paren / backtick / single quote | Step crashes with shell syntax error, CHANGELOG not updated | CHANGELOG written verbatim |
| PR body is plain ASCII without special chars | CHANGELOG written | Same — CHANGELOG written |
| `release/next` flow with no `CHANGELOG.old.md` present | Wrote empty (referenced undefined `steps.get_description.outputs.DESCRIPTION`) | Writes the actual `$DESCRIPTION` |

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Local repro: `DESCRIPTION="customer's (FR-24632)" printf '%s\n' "\$DESCRIPTION"` writes the string verbatim with no shell error.
- [ ] Next merge to `master` exercises `onPullRequestMerged` end-to-end (will validate on first real release after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)