### PR TITLE
fix(sdk): force token refresh on switchTenant to fix stale entitlements

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -335,8 +335,12 @@ class FronteggAuthService(
                 }
             }
 
+            // Tokens are tenant-bound (tenantId is a JWT claim), so a tenant switch must
+            // always issue a real refresh — even if the current access token's TTL has
+            // not elapsed. Otherwise the SDK keeps acting as the previous tenant until
+            // the next auto-refresh fires.
             val success = try {
-                refreshIdempotent()
+                refreshIdempotent(force = true)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to refresh token during tenant switch", e)
                 false
@@ -365,23 +369,32 @@ class FronteggAuthService(
      * Uses a coroutine Mutex so that concurrent callers suspend and wait for the
      * in-progress refresh instead of silently returning. After acquiring the lock
      * each caller re-checks token validity to avoid redundant API calls.
+     *
+     * Set [force] = true for callers (like tenant switch) that need a real refresh
+     * even when the current access token has time on its TTL. Frontegg access tokens
+     * are tenant-bound (tenantId is in the JWT claims), so after switching tenants
+     * the existing token is "still valid" by TTL but stale by tenant — skipping
+     * the refresh would leave the SDK acting as the previous tenant.
      */
     private suspend fun refreshIdempotent(
         source: RefreshInvocationSource = RefreshInvocationSource.MANUAL_USER,
-        processQueueAfterSuccess: Boolean = true
+        processQueueAfterSuccess: Boolean = true,
+        force: Boolean = false
     ): Boolean {
         if (isAutoRefreshBlocked(source)) {
             Log.d(TAG, "Skipping auto refresh (FRONTEGG_DISABLE_AUTO_REFRESH=true)")
             return false
         }
         val success = refreshMutex.withLock {
-            val currentAccessToken = accessToken.value
-            if (currentAccessToken != null) {
-                val decoded = JWTHelper.decode(currentAccessToken)
-                val offset = decoded.exp.calculateTimerOffset()
-                if (offset > 0) {
-                    Log.d(TAG, "refreshIdempotent: token already refreshed by concurrent call, skipping")
-                    return@withLock true
+            if (!force) {
+                val currentAccessToken = accessToken.value
+                if (currentAccessToken != null) {
+                    val decoded = JWTHelper.decode(currentAccessToken)
+                    val offset = decoded.exp.calculateTimerOffset()
+                    if (offset > 0) {
+                        Log.d(TAG, "refreshIdempotent: token already refreshed by concurrent call, skipping")
+                        return@withLock true
+                    }
                 }
             }
 

--- a/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
@@ -382,6 +382,73 @@ class FronteggAuthServiceTest {
     }
 
     @Test
+    fun `switchTenant forces a token refresh even when the existing access token is still valid by TTL`() {
+        // Regression: Frontegg access tokens are tenant-bound (tenantId lives in the JWT
+        // claims), so any tenant switch must re-mint tokens. Pre-fix, switchTenant fell
+        // through to refreshIdempotent's skip-if-not-expired guard
+        // (FronteggAuthService.kt:377-386). When the existing access token still had time
+        // on its TTL the guard returned success without actually refreshing, leaving
+        // accessToken.value pinned to the OLD tenant's JWT. Subsequent calls to
+        // loadEntitlements(forceRefresh=true) sent the stale token to the entitlements
+        // API, which reads tenant from the JWT and returned the previous tenant's
+        // entitlement set — so getFeatureEntitlements("sso") kept reporting
+        // isEntitled=true even after a switch to a tenant that did not have SSO. The
+        // state only self-healed when the access token's TTL elapsed (~45s) and
+        // auto-refresh fired.
+        //
+        // Expected (post-fix): switchTenant always issues a real refresh so the access
+        // token's tenantId claim matches the newly-switched tenant.
+
+        every { storageMock.enableSessionPerTenant }.returns(false)
+
+        // Existing session: access token whose `exp` is well in the future — this is the
+        // exact condition under which the skip-if-not-expired guard would have fired.
+        auth.accessToken.value = "stale-tenant-A-access-token"
+        auth.refreshToken.value = "current-refresh-token"
+
+        mockkObject(JWTHelper)
+        val jwt = JWT()
+        jwt.exp = (System.currentTimeMillis() / 1000) + 3600 // 1 hour in the future
+        every { JWTHelper.decode(any()) }.returns(jwt)
+
+        // Server-side switch succeeds.
+        every { apiMock.switchTenant(any()) }.returns(Unit)
+        every { apiMock.evictIdleConnections() }.returns(Unit)
+
+        // Server mints tenant-B-bound tokens on the next refresh.
+        val tenantBAuth = AuthResponse().apply {
+            id_token = "id-token-for-B"
+            refresh_token = "refresh-token-for-B"
+            access_token = "access-token-for-B"
+            token_type = "Bearer"
+        }
+        every { apiMock.refreshToken(any()) }.returns(tenantBAuth)
+
+        val tenantB = Tenant().apply { id = "tenant-B"; tenantId = "tenant-B" }
+        val user = User().apply {
+            id = "user-1"
+            tenants = listOf(tenantB)
+            activeTenant = tenantB
+        }
+        every { apiMock.me() }.returns(user)
+
+        every { credentialManagerMock.save(any(), any()) }.returns(true)
+        every { credentialManagerMock.save(any(), any(), any()) }.returns(true)
+        every { credentialManagerMock.getCurrentTenantId() }.returns(null)
+        every { Log.w(any(), any<String>()) } returns 0
+
+        auth.switchTenant("tenant-B")
+
+        // Pre-fix: 0 calls (skip-if-not-expired guard hit, no real refresh). Post-fix: 1.
+        verify(timeout = 2_000, exactly = 1) { apiMock.refreshToken("current-refresh-token") }
+
+        // And the freshly-minted tenant-B token must replace the stale tenant-A one in memory.
+        assert(auth.accessToken.value == "access-token-for-B") {
+            "accessToken.value must reflect the freshly-issued tenant-B token, was ${auth.accessToken.value}"
+        }
+    }
+
+    @Test
     fun `loginWithPasskeys should call Api_webAuthnPrelogin`() {
         val request = WebAuthnAssertionRequest(
             cookie = "TestCookie",


### PR DESCRIPTION
## Summary

- Threads a `force` flag through `refreshIdempotent` so callers that need a real refresh — even when the current access token has time on its TTL — can bypass the v1.3.23 skip-if-not-expired guard.
- `switchTenant` now passes `force = true`. Frontegg access tokens are tenant-bound (tenantId is a JWT claim), so a tenant switch must always re-mint tokens.
- Adds `switchTenant forces a token refresh even when the existing access token is still valid by TTL` to `FronteggAuthServiceTest` as the regression reproduction.

## Why

Retail Success report: `fronteggAuth.getFeatureEntitlements` kept returning `isEntitled: true` after switching to a tenant that did not have the feature — even when the host app explicitly called `loadEntitlements(forceRefresh = true)` before the check. Web behaved correctly; Android did not.

Tracing the bug:
1. `switchTenant(B)` → `api.switchTenant(B)` flips the user's active tenant on the server. The PUT does not return new tokens — the comment at [FronteggAuthService.kt:778](https://github.com/frontegg/frontegg-android-kotlin/blob/master/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt#L778) already calls this out: _"Tokens are tenant-dependent; refresh to get tokens for the desired tenant."_
2. With `enableSessionPerTenant = false` (default), the flow falls through to `refreshIdempotent()` to obtain a tenant-B-bound token.
3. `refreshIdempotent`'s [skip-if-not-expired guard](https://github.com/frontegg/frontegg-android-kotlin/blob/master/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt#L377-L386) (added in v1.3.23, commit `623b118`) sees that the existing access token still has time on its `exp` claim and equates "valid by TTL" with "already refreshed by a concurrent caller." That equivalence is wrong here: the token is still valid by TTL but carries the *previous* tenant's claims. The guard returns success without refreshing.
4. `accessToken.value` stays pinned to the tenant-A token. `loadEntitlements(forceRefresh = true)` correctly bypasses the entitlement-layer cache but sends the stale tenant-A access token to `/frontegg/entitlements/api/v2/user-entitlements`. The entitlements API reads tenant from the JWT claims, so it returns tenant A's entitlement set — which (in the customer's scenario) includes `sso`.
5. `getFeatureEntitlements("sso")` returns `isEntitled: true` for ~45s until the access token's TTL elapses and `refreshTokenTimer` fires `sendRefreshTokenInternal`, which refreshes unconditionally and finally produces a tenant-B token.

This is pre-acknowledged in the test comment at [FronteggAuthServiceTest.kt:797-801](https://github.com/frontegg/frontegg-android-kotlin/blob/master/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt#L797-L801) ("…fell through to refreshIdempotent and hit the v1.3.23 skip-if-not-expired guard, so state stayed on A until the access token expired (~45s) and auto-refresh fired"). PR #242 closed an *upstream* path that wrongly triggered this same chain; this PR closes the underlying refresh guard for the explicit `switchTenant` entry point.

## Behaviour change

| Scenario | Before | After |
| --- | --- | --- |
| `switchTenant(B)` while current access token still has TTL left, `enableSessionPerTenant = false` | `refreshIdempotent` skipped the refresh; `accessToken.value` kept tenant-A claims for up to ~45s | `refreshIdempotent(force = true)` always refreshes; `accessToken.value` reflects tenant-B immediately |
| `switchTenant(B)` while current access token already expired | Refreshed (guard not triggered) | Same — refreshes |
| `switchTenant(B)` with `enableSessionPerTenant = true` and a per-tenant cached token for B | Used cached tenant-B token (path A) | Same — uses cached tenant-B token |
| `switchTenant(B)` with `enableSessionPerTenant = true` but no cached tokens for B | Fell through to `refreshIdempotent` (same bug) | Now also force-refreshes |
| Auto-refresh / concurrent-caller dedup via `refreshIdempotent` (default `force = false`) | Skip-if-not-expired guard active | Unchanged — guard still active |

## Test plan

- [x] New regression test fails on master at the `verify(exactly = 1) { apiMock.refreshToken(...) }` line (0 calls observed pre-fix).
- [x] New regression test passes after the fix (1 call observed; `accessToken.value` reflects the freshly-minted tenant-B token).
- [x] `./gradlew :android:testDebugUnitTest` — 496/496 pass.
- [ ] Manual: reproduce the customer's setup (tenant A with `sso`, tenant B without). Sign in to A on Android, call `switchTenant(B)`, then `loadEntitlements(forceRefresh = true) { ... }`, then `getFeatureEntitlements("sso")`. Expect `isEntitled = false` immediately, not after a ~45s wait.
- [ ] E2E suite (rerun on CI).

## Out of scope

- Auto-refreshing entitlements after a successful `switchTenant`. Host apps must still call `loadEntitlements(forceRefresh = true)` themselves — same contract as today. Wiring it into `switchTenant` (mirroring `updateStateWithCredentials` at line 936) would be a nice ergonomics follow-up.
- Clearing `entitlements._state` at the start of `switchTenant` so `checkFeature` returns `ENTITLEMENTS_NOT_LOADED` during the transition instead of the stale tenant-A view. More honest signal, but a behaviour change for host apps that currently read entitlements during the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)