### PR TITLE
fix(sdk): redact OAuth code and tokens from URL log lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## v
+## Summary
+
+Redact OAuth-sensitive query parameters from URLs before they reach `Log.d`.
+
+A customer pentest report flagged that the SDK emits the OAuth authorization code (and PKCE `code_verifier` / `code_challenge`, `nonce`, `state`) in plaintext to logcat during the login flow. The leak occurred in the embedded WebView path — host apps that suppress their own logs in production (e.g. Capacitor's `loggingBehavior: 'production'`) had no way to silence the SDK's output, so the code remained visible to anything with ADB access.
+
+- New `LogUrlSanitizer` utility strips sensitive query-parameter values (`code`, `state`, `code_verifier`, `code_challenge`, `nonce`, `access_token`, `refresh_token`, `id_token`, bearer / authorization tokens, etc.) and replaces them with `[redacted]` before logging.
+- Applied at every `Log.d` call site that prints a URL: `EmbeddedAuthActivity`, `AuthorizeUrlGenerator`, `FronteggWebClient.shouldInterceptRequest`, `AdminPortalActivity`.
+- Key set kept in sync with `SentryHelper` so logcat and Sentry redact the same parameters.
+
+## v
 - Minor enhance switch tenants logic
 - route `switchTenant` through `updateStateWithCredentials` and fires `loadEntitlements(forceRefresh = true)` on the new tenant's token
 

--- a/android/src/main/java/com/frontegg/android/AdminPortalActivity.kt
+++ b/android/src/main/java/com/frontegg/android/AdminPortalActivity.kt
@@ -14,6 +14,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.view.WindowCompat
 import com.frontegg.android.ui.FronteggBaseActivity
+import com.frontegg.android.utils.LogUrlSanitizer
 
 /**
  * Embedded Frontegg admin portal — opens `${baseUrl}/oauth/portal?appId=<applicationId>`
@@ -109,7 +110,7 @@ class AdminPortalActivity : FronteggBaseActivity() {
     private fun buildPortalUrl(): String {
         val auth = applicationContext.fronteggAuth
         val url = buildPortalUrl(auth.baseUrl, auth.applicationId)
-        Log.d(TAG, "loading $url")
+        Log.d(TAG, "loading ${LogUrlSanitizer.sanitize(url)}")
         return url
     }
 

--- a/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
+++ b/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
@@ -17,6 +17,7 @@ import com.frontegg.android.ui.DefaultLoader
 import com.frontegg.android.ui.FronteggBaseActivity
 import com.frontegg.android.utils.AppIdHeaderHelper
 import com.frontegg.android.utils.AuthorizeUrlGenerator
+import com.frontegg.android.utils.LogUrlSanitizer
 import com.frontegg.android.utils.NullableObject
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.functions.Consumer
@@ -209,7 +210,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             webViewUrl = intentUrl.toString()
         }
 
-        Log.d(TAG, "webViewUrl: $webViewUrl")
+        Log.d(TAG, "webViewUrl: ${LogUrlSanitizer.sanitize(webViewUrl)}")
         
         if (webViewUrl == null) {
             Log.d(TAG, "webViewUrl is null, returning")
@@ -239,7 +240,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
         
         // If it's an account action URL (reset-password, etc.), load immediately without checking auth state
         if (isPasswordResetOrAccountAction || isSocialLoginRedirect) {
-            Log.d(TAG, "loadUrl (account action/social redirect): $webViewUrl")
+            Log.d(TAG, "loadUrl (account action/social redirect): ${LogUrlSanitizer.sanitize(webViewUrl)}")
             webView.loadUrl(webViewUrl!!, AppIdHeaderHelper.getHeaders())
             webViewUrl = null
             return
@@ -252,7 +253,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
                 (!fronteggAuth.initializing.value &&
                         !fronteggAuth.isAuthenticated.value)
         ) {
-            Log.d(TAG, "loadUrl $webViewUrl")
+            Log.d(TAG, "loadUrl ${LogUrlSanitizer.sanitize(webViewUrl)}")
             webView.loadUrl(webViewUrl!!, AppIdHeaderHelper.getHeaders())
             webViewUrl = null
         } else {
@@ -352,7 +353,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             if (isPasswordResetOrAccountAction || 
                 fronteggAuth.isStepUpAuthorization.value ||
                 (!fronteggAuth.initializing.value && !fronteggAuth.isAuthenticated.value)) {
-                Log.d(TAG, "Retrying loadUrl in onResume: $webViewUrl")
+                Log.d(TAG, "Retrying loadUrl in onResume: ${LogUrlSanitizer.sanitize(webViewUrl)}")
                 webView.loadUrl(webViewUrl!!, AppIdHeaderHelper.getHeaders())
                 webViewUrl = null
             }

--- a/android/src/main/java/com/frontegg/android/embedded/FronteggWebClient.kt
+++ b/android/src/main/java/com/frontegg/android/embedded/FronteggWebClient.kt
@@ -29,6 +29,7 @@ import com.frontegg.android.utils.Constants
 import com.frontegg.android.utils.Constants.Companion.loginRoutes
 import com.frontegg.android.utils.Constants.Companion.socialLoginRedirectUrl
 import com.frontegg.android.utils.Constants.Companion.successLoginRoutes
+import com.frontegg.android.utils.LogUrlSanitizer
 import com.frontegg.android.utils.generateErrorPage
 import com.google.gson.JsonParser
 import kotlinx.coroutines.CoroutineDispatcher
@@ -463,14 +464,15 @@ class FronteggWebClient(
         if (storage.useDiskCacheWebview) {
             request?.let {
                 val url = it.url.toString()
-                Log.d(TAG, "shouldInterceptRequest: $url")
+                val sanitizedUrl = LogUrlSanitizer.sanitize(url)
+                Log.d(TAG, "shouldInterceptRequest: $sanitizedUrl")
                 if (cache.shouldCache(url)) {
-                    Log.d(TAG, "shouldInterceptRequest: cacheable $url")
+                    Log.d(TAG, "shouldInterceptRequest: cacheable $sanitizedUrl")
                     cache.get(url)?.let { response ->
                         return response
                     }
                 } else {
-                    Log.d(TAG, "shouldInterceptRequest: not cacheable $url")
+                    Log.d(TAG, "shouldInterceptRequest: not cacheable $sanitizedUrl")
                 }
             }
         }

--- a/android/src/main/java/com/frontegg/android/utils/AuthorizeUrlGenerator.kt
+++ b/android/src/main/java/com/frontegg/android/utils/AuthorizeUrlGenerator.kt
@@ -132,7 +132,7 @@ class AuthorizeUrlGenerator(
         }
 
         val url = authorizeUrlBuilder.build().toString()
-        Log.d(TAG, "Generated url: $url")
+        Log.d(TAG, "Generated url: ${LogUrlSanitizer.sanitize(url)}")
 
         return Pair(url, codeVerifier)
     }

--- a/android/src/main/java/com/frontegg/android/utils/LogUrlSanitizer.kt
+++ b/android/src/main/java/com/frontegg/android/utils/LogUrlSanitizer.kt
@@ -1,0 +1,94 @@
+package com.frontegg.android.utils
+
+import java.util.Locale
+
+/**
+ * Strips OAuth-sensitive query parameters from a URL before it is written to
+ * logcat. The SDK historically logged full callback URIs at `Log.d` level, which
+ * exposed the OAuth `code`, `state`, PKCE `code_verifier` / `code_challenge`,
+ * and bearer tokens to any process with logcat access (e.g. ADB on a debug
+ * device, or a host app that piped logcat off-device).
+ *
+ * The sanitizer is intentionally string-based and has no Android framework
+ * dependency so it stays cheap to run, safe to call before `Log` is initialised
+ * during early SDK startup, and trivially unit-testable on the JVM.
+ *
+ * Keys kept in sync with [SentryHelper] breadcrumb sanitisation so logcat and
+ * Sentry redact the same set.
+ */
+internal object LogUrlSanitizer {
+
+    private const val REDACTED = "[redacted]"
+
+    /** Exact match (case-insensitive) — every value gets dropped. */
+    private val SENSITIVE_EXACT = setOf(
+        "code",
+        "state",
+        "nonce",
+        "jwt",
+        "bearer",
+        "verifier",
+        "code_verifier",
+        "code_challenge",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "device_token",
+        "client_secret",
+        "mfa_token",
+        "authorization",
+        "password",
+        "passwd",
+        "secret",
+    )
+
+    /** Substring match (case-insensitive) — catches things like `*_token`, `x-api-key`. */
+    private val SENSITIVE_CONTAINS = listOf(
+        "token",
+        "secret",
+        "password",
+        "authorization",
+        "credential",
+        "signature",
+        "apikey",
+        "api_key",
+        "access_key",
+    )
+
+    /**
+     * Returns the URL with sensitive query-parameter values replaced by
+     * `[redacted]`. Anything that is not a parseable URL (or is null / blank)
+     * is returned unchanged so call sites can use this unconditionally without
+     * losing diagnostic value.
+     */
+    fun sanitize(url: String?): String {
+        if (url.isNullOrEmpty()) return url ?: "null"
+
+        val queryStart = url.indexOf('?')
+        if (queryStart < 0) return url
+
+        val fragmentStart = url.indexOf('#', startIndex = queryStart)
+        val queryEnd = if (fragmentStart >= 0) fragmentStart else url.length
+
+        val prefix = url.substring(0, queryStart + 1)
+        val query = url.substring(queryStart + 1, queryEnd)
+        val suffix = if (fragmentStart >= 0) url.substring(fragmentStart) else ""
+
+        if (query.isEmpty()) return url
+
+        val sanitisedQuery = query.split('&').joinToString("&") { pair ->
+            val eq = pair.indexOf('=')
+            if (eq < 0) return@joinToString pair
+            val key = pair.substring(0, eq)
+            if (isSensitive(key)) "$key=$REDACTED" else pair
+        }
+
+        return prefix + sanitisedQuery + suffix
+    }
+
+    private fun isSensitive(rawKey: String): Boolean {
+        val key = rawKey.lowercase(Locale.US)
+        if (key in SENSITIVE_EXACT) return true
+        return SENSITIVE_CONTAINS.any { key.contains(it) }
+    }
+}

--- a/android/src/test/java/com/frontegg/android/utils/LogUrlSanitizerTest.kt
+++ b/android/src/test/java/com/frontegg/android/utils/LogUrlSanitizerTest.kt
@@ -1,0 +1,92 @@
+package com.frontegg.android.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LogUrlSanitizerTest {
+
+    @Test
+    fun `null url returns literal null string`() {
+        assertEquals("null", LogUrlSanitizer.sanitize(null))
+    }
+
+    @Test
+    fun `url without query is returned unchanged`() {
+        val url = "https://example.frontegg.com/oauth/account/login"
+        assertEquals(url, LogUrlSanitizer.sanitize(url))
+    }
+
+    @Test
+    fun `oauth callback code is redacted`() {
+        val url = "frontegg://callback?code=abc123&state=xyz"
+        assertEquals(
+            "frontegg://callback?code=[redacted]&state=[redacted]",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `non sensitive params are preserved alongside sensitive ones`() {
+        val url = "https://example.frontegg.com/cb?prompt=consent&code=abc&tenant=acme"
+        assertEquals(
+            "https://example.frontegg.com/cb?prompt=consent&code=[redacted]&tenant=acme",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `pkce code_verifier and code_challenge are redacted`() {
+        val url = "https://example/authorize?code_verifier=AAA&code_challenge=BBB&nonce=CCC"
+        assertEquals(
+            "https://example/authorize?code_verifier=[redacted]&code_challenge=[redacted]&nonce=[redacted]",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `tokens are redacted via substring match`() {
+        val url = "https://example/cb?access_token=A&refresh_token=B&id_token=C&device_token=D"
+        assertEquals(
+            "https://example/cb?access_token=[redacted]&refresh_token=[redacted]&id_token=[redacted]&device_token=[redacted]",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `case insensitive match`() {
+        val url = "https://example/cb?Code=abc&STATE=xyz"
+        assertEquals(
+            "https://example/cb?Code=[redacted]&STATE=[redacted]",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `fragment is preserved`() {
+        val url = "https://example/cb?code=abc#section"
+        assertEquals(
+            "https://example/cb?code=[redacted]#section",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `query keys without values are passed through`() {
+        val url = "https://example/cb?flag&code=abc"
+        assertEquals(
+            "https://example/cb?flag&code=[redacted]",
+            LogUrlSanitizer.sanitize(url),
+        )
+    }
+
+    @Test
+    fun `empty query is returned unchanged`() {
+        val url = "https://example/cb?"
+        assertEquals(url, LogUrlSanitizer.sanitize(url))
+    }
+
+    @Test
+    fun `blank string is returned unchanged`() {
+        assertEquals("", LogUrlSanitizer.sanitize(""))
+    }
+}


### PR DESCRIPTION
## Summary

A customer pentest found the Frontegg Android SDK emits the OAuth authorization code in plaintext to logcat during the embedded WebView login flow (e.g. `code=<value>` visible in `Log.d` output). The customer's host app suppresses its own logs in production via Capacitor's `loggingBehavior: 'production'`, but the SDK was logging unconditionally — exposing the authorization code to anything with ADB access on a device that's been compromised or left in dev mode.

This PR redacts OAuth-sensitive query-parameter values from URLs before they reach `Log.d`.

## What was leaking

| File | Line | What was logged |
|---|---|---|
| `EmbeddedAuthActivity.kt` | 212 | full callback URL with `?code=...&state=...` |
| `EmbeddedAuthActivity.kt` | 242 | same, for social-login redirect path |
| `EmbeddedAuthActivity.kt` | 255 | same, for OAuth callback path |
| `EmbeddedAuthActivity.kt` | 355 | same, for the `onResume` retry path |
| `AuthorizeUrlGenerator.kt` | 135 | generated authorize URL with `code_challenge` + `nonce` |
| `FronteggWebClient.kt` | 466/468/473 | every URL the WebView loads (incl. OAuth callback redirects) |
| `AdminPortalActivity.kt` | 112 | admin portal URL (precautionary) |

Sentry breadcrumbs were already redacted via `SentryHelper` — only logcat was leaky.

## Approach

New `internal object LogUrlSanitizer` in `com.frontegg.android.utils`:
- Pure-Kotlin string ops (no `android.net.Uri` dep) → cheap, unit-testable on the JVM, safe to call during early SDK startup.
- Strips values for `code`, `state`, `code_verifier`, `code_challenge`, `nonce`, `access_token`, `refresh_token`, `id_token`, `device_token`, `mfa_token`, plus any key containing `token`, `secret`, `password`, `authorization`, `credential`, `signature`, `apikey`, `access_key`.
- No-op on URLs without a query → can be applied unconditionally without losing diagnostic value.
- Key set mirrors `SentryHelper.breadcrumbKeyIsSensitive` so logcat and Sentry redact the same set going forward.

Applied at every URL `Log.d` site listed above.

## Why not just gate on `BuildConfig.DEBUG`?

Two reasons:
1. The SDK module's `BuildConfig.DEBUG` is always `false` in published artifacts — gating on it would silence the logs entirely, including in customer apps' debug builds, where the SDK logs are genuinely useful for diagnosing integration issues.
2. Defense-in-depth: even a developer using a debug build of their own app shouldn't be able to accidentally screenshot / share a log line containing a real OAuth code.

A runtime `enableDebugLogging` flag is a reasonable follow-up but is out of scope here — this PR is the focused leak fix.

## Test plan

- [x] New unit test `LogUrlSanitizerTest` (11 cases): null/empty, no query, OAuth callback, PKCE, tokens, case-insensitive, fragment preservation, key-without-value, mixed safe + sensitive params
- [x] `./gradlew :android:testDebugUnitTest --tests "com.frontegg.android.utils.LogUrlSanitizerTest"` passes
- [x] `./gradlew :android:testDebugUnitTest --tests "com.frontegg.android.utils.*"` (including `AuthorizeUrlGeneratorTest`, `SentryHelperTest`) still passes
- [ ] Manual: capture logcat during embedded login and confirm the previously-leaking lines now show `code=[redacted]`

## Risk

- Sanitizer is purely additive at log sites — none of the actual URL handling, navigation, or token-exchange logic is touched.
- For URLs without a query string, sanitizer is a pass-through.