### PR TITLE
fix(sdk): defensive Tenant.equals/hashCode for partially-deserialized tenants

### DIFF
--- a/android/src/main/java/com/frontegg/android/models/Tenant.kt
+++ b/android/src/main/java/com/frontegg/android/models/Tenant.kt
@@ -13,38 +13,67 @@ class Tenant {
     lateinit var vendorId: String
     var website: String? = null
 
+    /**
+     * Safe-access helpers around the `lateinit var` fields. Gson silently leaves
+     * a `lateinit var` uninitialized when the corresponding JSON field is absent
+     * from the response, and any subsequent direct read on the property throws
+     * [UninitializedPropertyAccessException].
+     *
+     * That bites particularly hard in `/me`-style responses scoped by
+     * `applicationId` where the server can omit fields like `metadata`,
+     * `createdAt`, `updatedAt`, `vendorId`, etc. — and previously `equals()`
+     * crashed the host app's `==` comparison the moment any one of those
+     * fields was missing on either side. Pavel hit exactly that on the
+     * embedded demo (`TenantAdapter.getView:39` — `if (tenant == activeTenant)`)
+     * which blocked QA of the entitlements work in PR #257.
+     *
+     * Direct reads on `tenant.id` etc. still throw if the field was missing —
+     * keeping that behavior so host code that explicitly relies on the field
+     * being present surfaces the bug rather than silently seeing `""`. Only
+     * `equals` and `hashCode` are made defensive, because those are calls the
+     * JDK / Kotlin standard library invoke without the host app knowing
+     * (collection lookups, set membership, `==`, etc.).
+     */
+    private fun safeId(): String? = if (this::id.isInitialized) id else null
+    private fun safeName(): String? = if (this::name.isInitialized) name else null
+    private fun safeTenantId(): String? = if (this::tenantId.isInitialized) tenantId else null
+    private fun safeCreatedAt(): String? = if (this::createdAt.isInitialized) createdAt else null
+    private fun safeUpdatedAt(): String? = if (this::updatedAt.isInitialized) updatedAt else null
+    private fun safeMetadata(): String? = if (this::metadata.isInitialized) metadata else null
+    private fun safeVendorId(): String? = if (this::vendorId.isInitialized) vendorId else null
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
         other as Tenant
 
-        if (id != other.id) return false
-        if (name != other.name) return false
+        if (safeId() != other.safeId()) return false
+        if (safeName() != other.safeName()) return false
         if (creatorEmail != other.creatorEmail) return false
         if (creatorName != other.creatorName) return false
-        if (tenantId != other.tenantId) return false
-        if (createdAt != other.createdAt) return false
-        if (updatedAt != other.updatedAt) return false
+        if (safeTenantId() != other.safeTenantId()) return false
+        if (safeCreatedAt() != other.safeCreatedAt()) return false
+        if (safeUpdatedAt() != other.safeUpdatedAt()) return false
         if (isReseller != other.isReseller) return false
-        if (metadata != other.metadata) return false
-        if (vendorId != other.vendorId) return false
+        if (safeMetadata() != other.safeMetadata()) return false
+        if (safeVendorId() != other.safeVendorId()) return false
         if (website != other.website) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = id.hashCode()
-        result = 31 * result + name.hashCode()
+        var result = safeId()?.hashCode() ?: 0
+        result = 31 * result + (safeName()?.hashCode() ?: 0)
         result = 31 * result + (creatorEmail?.hashCode() ?: 0)
         result = 31 * result + (creatorName?.hashCode() ?: 0)
-        result = 31 * result + tenantId.hashCode()
-        result = 31 * result + createdAt.hashCode()
-        result = 31 * result + updatedAt.hashCode()
+        result = 31 * result + (safeTenantId()?.hashCode() ?: 0)
+        result = 31 * result + (safeCreatedAt()?.hashCode() ?: 0)
+        result = 31 * result + (safeUpdatedAt()?.hashCode() ?: 0)
         result = 31 * result + isReseller.hashCode()
-        result = 31 * result + metadata.hashCode()
-        result = 31 * result + vendorId.hashCode()
+        result = 31 * result + (safeMetadata()?.hashCode() ?: 0)
+        result = 31 * result + (safeVendorId()?.hashCode() ?: 0)
         result = 31 * result + (website?.hashCode() ?: 0)
         return result
     }

--- a/android/src/test/java/com/frontegg/android/models/TenantTest.kt
+++ b/android/src/test/java/com/frontegg/android/models/TenantTest.kt
@@ -3,6 +3,8 @@ package com.frontegg.android.models
 import com.frontegg.android.fixtures.getTenant
 import com.frontegg.android.fixtures.tenantJson
 import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -19,5 +21,39 @@ class TenantTest {
         val tenantModel = Gson().fromJson(tenantJson, Tenant::class.java)
 
         assert(tenantModel == tenant)
+    }
+
+    @Test
+    fun `equals does not crash when a lateinit field is uninitialized on one side`() {
+        // Regression: Gson silently leaves `lateinit var` fields uninitialized when
+        // the corresponding JSON key is absent in the response — common for /me
+        // responses scoped by `applicationId`. Pre-fix, `tenant == other` crashed
+        // with UninitializedPropertyAccessException the moment `equals()` read the
+        // uninitialized field. The embedded demo's TenantAdapter.getView triggered
+        // exactly this when comparing the current tenant against each list item
+        // (`if (tenant == activeTenant)`), blocking QA of PR #257.
+        //
+        // Post-fix: equals reads via `isInitialized`-guarded accessors, treats
+        // uninitialized-vs-anything as "not equal" rather than crashing.
+        val partial = Gson().fromJson("""{"name":"PartialTenant"}""", Tenant::class.java)
+        val full = getTenant()
+
+        // The two are not equal (partial is missing every field except name) but
+        // the comparison itself must complete without throwing.
+        assertNotEquals(full, partial)
+        assertNotEquals(partial, full)
+        // hashCode must not throw either — collections like HashSet / HashMap call
+        // it without the host app's knowledge.
+        assertEquals(partial.hashCode(), partial.hashCode())
+    }
+
+    @Test
+    fun `equals returns true for two partially-deserialized tenants with the same shape`() {
+        // A second Gson decode of the same JSON should equal the first — even if
+        // most lateinit fields are uninitialized — because equals compares safely.
+        val a = Gson().fromJson("""{"name":"PartialTenant"}""", Tenant::class.java)
+        val b = Gson().fromJson("""{"name":"PartialTenant"}""", Tenant::class.java)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
     }
 }


### PR DESCRIPTION
## Summary

Tiny but high-value fix: `Tenant.equals` / `Tenant.hashCode` no longer crash when a `lateinit var` field is uninitialized on either side.

## Why

Gson silently leaves `lateinit var` fields uninitialized when the corresponding JSON key is absent — common with `/me`-style endpoints scoped by `applicationId`, where the server can omit `metadata`, `createdAt`, `updatedAt`, `vendorId`, etc. Direct reads on the missing field then throw `UninitializedPropertyAccessException`.

Pre-fix, `Tenant.equals()` read the lateinit fields directly, so `tenant == other` (and any collection lookup that walks through `hashCode`/`equals`) crashed the host app the moment either side had a missing field.

Pavel hit this on the embedded demo's `TenantAdapter`:

```
kotlin.UninitializedPropertyAccessException: lateinit property id has not been initialized
    at com.frontegg.demo.ui.home.TenantAdapter.getView(TenantAdapter.kt:39)
```

Line 39 is `if (tenant == activeTenant)`. This blocked QA of the entitlements work in [#257](https://github.com/frontegg/frontegg-android-kotlin/pull/257) — Pavel couldn't open the tenant switcher to do the FR-24821 reproduction.

## The fix

Route `equals` and `hashCode` through `isInitialized`-guarded accessors. Uninitialized vs anything is "not equal"; two tenants missing the same fields are still equal.

**Direct reads on `tenant.id` etc. still throw on missing fields** — preserving that surface so host code that explicitly depends on the field being present continues to fail loudly instead of silently seeing `""`. Only the equality/hashing contract is made defensive, because those are calls the JDK / Kotlin stdlib invoke without the host app's knowledge (`==`, `HashSet.contains`, `HashMap.get`, etc.).

## Tests

Two new tests in [`TenantTest`](android/src/test/java/com/frontegg/android/models/TenantTest.kt):

| Test | What it covers | FAILS without fix? |
|---|---|---|
| `equals does not crash when a lateinit field is uninitialized on one side` | JSON `{\"name\":\"PartialTenant\"}` compared against a fully-populated tenant; assertion is the comparison completes (and the two are not equal). | **Yes** — `UninitializedPropertyAccessException` on the `id` read inside equals. |
| `equals returns true for two partially-deserialized tenants with the same shape` | Two Gson decodes of the same minimal JSON compare equal and hash equal. | **Yes** (same crash). |

Differential verified by stashing the production change and re-running — both new tests throw without it, both pass with it.

## Verification

- [x] `./gradlew :android:testDebugUnitTest --tests "com.frontegg.android.models.TenantTest"` — passes with fix, throws without
- [x] `./gradlew :android:testDebugUnitTest` — full suite **507 / 0 failures**

## Notes

- Doesn't touch the demo `TenantAdapter` code — the SDK fix is sufficient. Demos keep doing `tenant == activeTenant`; equals just no longer blows up.
- Doesn't change the `lateinit var` declarations — that would be a public API change (host apps may currently rely on the crash behavior to detect missing fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)