### PR TITLE
docs(getting-started): declare applicationId before manifestPlaceholders

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,12 @@ def fronteggClientId = "{{FRONTEGG_CLIENT_ID}}"
 android {
     defaultConfig {
 
+        // applicationId must be set before manifestPlaceholders, because the
+        // "package_name" placeholder below reads it. defaultConfig is evaluated
+        // top-to-bottom, so if manifestPlaceholders comes first applicationId is
+        // still null and the manifest merge fails.
+        applicationId "com.example.myapp"
+
         manifestPlaceholders = [
                 "package_name"      : applicationId,
                 "frontegg_domain"   : fronteggDomain,
@@ -146,6 +152,12 @@ val fronteggClientId = "{{FRONTEGG_CLIENT_ID}}"
 
 android {
     defaultConfig {
+
+        // applicationId must be set before manifestPlaceholders, because the
+        // "package_name" placeholder below reads it. defaultConfig is evaluated
+        // top-to-bottom, so if manifestPlaceholders comes first applicationId is
+        // still null and the manifest merge fails.
+        applicationId = "com.example.myapp"
 
         manifestPlaceholders["package_name"] = applicationId.toString()
         manifestPlaceholders["frontegg_domain"] = fronteggDomain


### PR DESCRIPTION
## Problem

In `docs/getting-started.md`, the **Configure build config fields** section shows `manifestPlaceholders` at the *top* of `defaultConfig`, with `applicationId` never declared in the snippet:

```groovy
android {
    defaultConfig {
        manifestPlaceholders = [
                "package_name"      : applicationId,   // ← reads applicationId
                "frontegg_domain"   : fronteggDomain,
                "frontegg_client_id": fronteggClientId
        ]
        ...
    }
}
```

Gradle evaluates `defaultConfig { }` top-to-bottom. When a customer pastes this block above their existing `applicationId` line, `applicationId` resolves to `null`, the `package_name` placeholder is empty, and the AAR manifest merge fails. The Kotlin variant (`manifestPlaceholders["package_name"] = applicationId.toString()`) has the same ordering problem.

## Fix

Declare `applicationId` first in both the Groovy and Kotlin snippets, with a comment explaining that it must precede `manifestPlaceholders` because the `package_name` placeholder reads it.

This matches the SDK's own working example apps, which all declare `applicationId` before `manifestPlaceholders`:
- `app/build.gradle:34`
- `embedded/build.gradle:34`
- `applicationId/build.gradle:32`
- `multi-region/build.gradle:32`

Docs-only change. Mirrors the equivalent fix in frontegg-react-native PR #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)