### PR TITLE
refactor(sdk): replace deprecated startActivityForResult with startActivity (FR-19725)

### DIFF
--- a/android/src/main/java/com/frontegg/android/AuthenticationActivity.kt
+++ b/android/src/main/java/com/frontegg/android/AuthenticationActivity.kt
@@ -202,7 +202,6 @@ class AuthenticationActivity : FronteggBaseActivity() {
     }
 
     companion object {
-        const val OAUTH_LOGIN_REQUEST = 100001
         const val AUTHORIZE_URI = "com.frontegg.android.AUTHORIZE_URI"
         private const val AUTH_LAUNCHED = "com.frontegg.android.AUTH_LAUNCHED"
         private const val CUSTOM_TAB_LAUNCHED = "com.frontegg.android.CUSTOM_TAB_LAUNCHED"
@@ -234,7 +233,7 @@ class AuthenticationActivity : FronteggBaseActivity() {
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
 
         fun authenticateWithMultiFactor(
@@ -249,7 +248,7 @@ class AuthenticationActivity : FronteggBaseActivity() {
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
 
         fun authenticateWithStepUp(
@@ -266,7 +265,7 @@ class AuthenticationActivity : FronteggBaseActivity() {
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
     }
 }

--- a/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
+++ b/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
@@ -387,7 +387,6 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
     }
 
     companion object {
-        const val OAUTH_LOGIN_REQUEST = 100001
         const val AUTHORIZE_URI = "com.frontegg.android.AUTHORIZE_URI"
         const val DIRECT_LOGIN_ACTION_LAUNCHED = "com.frontegg.android.DIRECT_LOGIN_ACTION_LAUNCHED"
         const val DIRECT_LOGIN_ACTION_LAUNCHED_DONE =
@@ -426,7 +425,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             intent.putExtra(AUTH_LAUNCHED, true)
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
 
         fun directLoginAction(
@@ -442,7 +441,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             intent.putExtra(DIRECT_LOGIN_ACTION_TYPE, type)
             intent.putExtra(DIRECT_LOGIN_ACTION_DATA, data)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
 
 
             /**
@@ -457,7 +456,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
              * val authorizeUri = AuthorizeUrlGenerator().generate(null, directActionBase64)
              * intent.putExtra(AUTH_LAUNCHED, true)
              * intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
-             * activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+             * activity.startActivity(intent)
              */
         }
 
@@ -474,7 +473,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             intent.putExtra(AUTH_LAUNCHED, true)
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
 
         fun authenticateWithStepUp(
@@ -492,7 +491,7 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
             intent.putExtra(AUTH_LAUNCHED, true)
             intent.putExtra(AUTHORIZE_URI, authorizeUri.first)
             onAuthFinishedCallback = callback
-            activity.startActivityForResult(intent, OAUTH_LOGIN_REQUEST)
+            activity.startActivity(intent)
         }
 
         fun afterAuthentication(activity: Activity) {

--- a/android/src/main/java/com/frontegg/android/embedded/FronteggNativeBridge.kt
+++ b/android/src/main/java/com/frontegg/android/embedded/FronteggNativeBridge.kt
@@ -8,7 +8,6 @@ import android.util.Base64
 import android.util.Log
 import android.webkit.JavascriptInterface
 import androidx.browser.customtabs.CustomTabsIntent
-import com.frontegg.android.EmbeddedAuthActivity
 import com.frontegg.android.fronteggAuth
 import com.frontegg.android.services.FronteggInnerStorage
 import com.frontegg.android.services.FronteggState
@@ -79,10 +78,7 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
                 val customTabsIntent = CustomTabsIntent.Builder().setShowTitle(false).build()
                 customTabsIntent.intent.setPackage("com.android.chrome")
                 customTabsIntent.intent.setData(authorizationUrl)
-                (context as Activity).startActivityForResult(
-                    customTabsIntent.intent,
-                    EmbeddedAuthActivity.OAUTH_LOGIN_REQUEST
-                )
+                (context as Activity).startActivity(customTabsIntent.intent)
             } else {
                 val browserIntent = Intent(Intent.ACTION_VIEW, authorizationUrl)
                 browserIntent.addCategory(Intent.CATEGORY_BROWSABLE)

--- a/android/src/test/java/com/frontegg/android/AuthenticationActivityTest.kt
+++ b/android/src/test/java/com/frontegg/android/AuthenticationActivityTest.kt
@@ -1,0 +1,101 @@
+package com.frontegg.android
+
+import android.app.Activity
+import android.content.Intent
+import com.frontegg.android.services.CredentialManager
+import com.frontegg.android.services.FronteggAuthService
+import com.frontegg.android.services.FronteggInnerStorage
+import com.frontegg.android.services.StorageProvider
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression guard for FR-19725: the hosted-mode (Custom Tabs / system browser)
+ * auth launches must use [Activity.startActivity] (no request code), not the
+ * deprecated `startActivityForResult`. The result was never consumed via
+ * `onActivityResult`, so these tests lock in that each entry point still
+ * launches, targets [AuthenticationActivity], and no longer requests a result.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AuthenticationActivityTest {
+
+    private lateinit var activity: Activity
+    private lateinit var intentSlot: CapturingSlot<Intent>
+
+    @Before
+    fun setUp() {
+        activity = mockk(relaxed = true)
+        intentSlot = slot()
+        every { activity.startActivity(capture(intentSlot)) } returns Unit
+
+        // The entry points build an authorize URL via `AuthorizeUrlGenerator(activity)`,
+        // whose constructor reads StorageProvider + `context.fronteggAuth`. Satisfy those
+        // so the real generator runs (deterministic; its only side effect lands on the
+        // relaxed CredentialManager mock).
+        val storage = mockk<FronteggInnerStorage>(relaxed = true)
+        every { storage.baseUrl } returns "https://base.url.com"
+        every { storage.clientId } returns "TestClientId"
+        every { storage.applicationId } returns "TestApplicationId"
+        mockkObject(StorageProvider)
+        every { StorageProvider.getInnerStorage() } returns storage
+
+        val authService = mockk<FronteggAuthService>(relaxed = true)
+        every { authService.credentialManager } returns mockk<CredentialManager>(relaxed = true)
+        mockkStatic("com.frontegg.android.FronteggAppKt")
+        every { activity.fronteggAuth } returns authService
+    }
+
+    @After
+    fun tearDown() {
+        AuthenticationActivity.onAuthFinishedCallback = null
+        unmockkAll()
+    }
+
+    @Test
+    fun `authenticate launches AuthenticationActivity via startActivity without a request code`() {
+        AuthenticationActivity.authenticate(activity)
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            AuthenticationActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+
+    @Test
+    fun `authenticateWithMultiFactor launches AuthenticationActivity via startActivity without a request code`() {
+        AuthenticationActivity.authenticateWithMultiFactor(activity, "mfaLoginAction")
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            AuthenticationActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+
+    @Test
+    fun `authenticateWithStepUp launches AuthenticationActivity via startActivity without a request code`() {
+        AuthenticationActivity.authenticateWithStepUp(activity, null)
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            AuthenticationActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+}

--- a/android/src/test/java/com/frontegg/android/EmbeddedAuthActivityTest.kt
+++ b/android/src/test/java/com/frontegg/android/EmbeddedAuthActivityTest.kt
@@ -1,0 +1,113 @@
+package com.frontegg.android
+
+import android.app.Activity
+import android.content.Intent
+import com.frontegg.android.services.CredentialManager
+import com.frontegg.android.services.FronteggAuthService
+import com.frontegg.android.services.FronteggInnerStorage
+import com.frontegg.android.services.StorageProvider
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression guard for FR-19725: the embedded-mode auth launches must use
+ * [Activity.startActivity] (no request code), not the deprecated
+ * `startActivityForResult`. The result was never consumed via `onActivityResult`,
+ * so these tests lock in that each entry point still launches, targets
+ * [EmbeddedAuthActivity], and no longer requests a result.
+ */
+@RunWith(RobolectricTestRunner::class)
+class EmbeddedAuthActivityTest {
+
+    private lateinit var activity: Activity
+    private lateinit var intentSlot: CapturingSlot<Intent>
+
+    @Before
+    fun setUp() {
+        activity = mockk(relaxed = true)
+        intentSlot = slot()
+        every { activity.startActivity(capture(intentSlot)) } returns Unit
+
+        // The entry points build an authorize URL via `AuthorizeUrlGenerator(activity)`,
+        // whose constructor reads StorageProvider + `context.fronteggAuth`. Satisfy those
+        // so the real generator runs (deterministic; its only side effect lands on the
+        // relaxed CredentialManager mock).
+        val storage = mockk<FronteggInnerStorage>(relaxed = true)
+        every { storage.baseUrl } returns "https://base.url.com"
+        every { storage.clientId } returns "TestClientId"
+        every { storage.applicationId } returns "TestApplicationId"
+        mockkObject(StorageProvider)
+        every { StorageProvider.getInnerStorage() } returns storage
+
+        val authService = mockk<FronteggAuthService>(relaxed = true)
+        every { authService.credentialManager } returns mockk<CredentialManager>(relaxed = true)
+        mockkStatic("com.frontegg.android.FronteggAppKt")
+        every { activity.fronteggAuth } returns authService
+    }
+
+    @After
+    fun tearDown() {
+        EmbeddedAuthActivity.onAuthFinishedCallback = null
+        unmockkAll()
+    }
+
+    @Test
+    fun `authenticate launches EmbeddedAuthActivity via startActivity without a request code`() {
+        EmbeddedAuthActivity.authenticate(activity)
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            EmbeddedAuthActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+
+    @Test
+    fun `directLoginAction launches EmbeddedAuthActivity via startActivity without a request code`() {
+        EmbeddedAuthActivity.directLoginAction(activity, "type", "data")
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            EmbeddedAuthActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+
+    @Test
+    fun `authenticateWithMultiFactor launches EmbeddedAuthActivity via startActivity without a request code`() {
+        EmbeddedAuthActivity.authenticateWithMultiFactor(activity, "mfaLoginAction")
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            EmbeddedAuthActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+
+    @Test
+    fun `authenticateWithStepUp launches EmbeddedAuthActivity via startActivity without a request code`() {
+        EmbeddedAuthActivity.authenticateWithStepUp(activity, null)
+
+        verify(exactly = 1) { activity.startActivity(any()) }
+        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
+        assertEquals(
+            EmbeddedAuthActivity::class.java.name,
+            intentSlot.captured.component?.className
+        )
+    }
+}


### PR DESCRIPTION
## What & why

Closes **FR-19725** — _[Mobile SDK] Replace startActivityForResult with the new Activity Result API_.

While implementing this I found the ticket's framing doesn't fit the codebase: the SDK launches its auth activities with `startActivityForResult`, but **the result is never consumed** — there is no `onActivityResult` override anywhere in the SDK. Auth outcomes are delivered through the static `onAuthFinishedCallback` field instead, so the request-code / result-code contract is **dead code**.

Given that, adopting `registerForActivityResult` would add ceremony *and* force a **breaking API change** on integrators (a launcher must be registered before the host `Activity` reaches `STARTED`, but the SDK is handed a running activity mid-lifecycle through static methods) — all to arrive at the exact same behavior. So this PR removes the deprecated API instead of ritually replacing it.

## Changes

- Replace all `startActivityForResult(intent, OAUTH_LOGIN_REQUEST)` launches with `startActivity(intent)`:
  - `AuthenticationActivity` — `authenticate`, `authenticateWithMultiFactor`, `authenticateWithStepUp`
  - `EmbeddedAuthActivity` — `authenticate`, `directLoginAction`, `authenticateWithMultiFactor`, `authenticateWithStepUp`
  - `FronteggNativeBridge` — Chrome Custom Tabs launch (custom tabs return via deep-link redirect, never an activity result)
- Remove the now-unused `OAUTH_LOGIN_REQUEST` request-code constants and the now-unused `EmbeddedAuthActivity` import in the bridge.

## Behavior impact

**None.** `startActivity` is equivalent to `startActivityForResult(intent, -1)`, and the `onAuthFinishedCallback` delivery path is untouched. The `setResult(...)` calls remain (harmless no-ops now, not deprecated) to keep the diff focused. Public API surface (`FronteggAuth.login` / `directLoginAction` / MFA / step-up) is unchanged.

## Note for reviewer

`OAUTH_LOGIN_REQUEST` was a `public const val` in the activity companion objects. It's an internal request code tied to the removed pattern with no cross-repo consumers, so it's removed here. If we'd rather preserve strict source compat, say the word and I'll keep the constants as `@Deprecated` no-ops.

## Testing

- `./gradlew :android:compileReleaseKotlin :android:compileDebugUnitTestKotlin` -> BUILD SUCCESSFUL
- Manual smoke test recommended across the four launch paths: hosted login, embedded login, MFA, and step-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)