### PR TITLE
fix(auth): reschedule token refresh for TTLs over 100s (identity-based dedup)

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -423,6 +423,27 @@ class FronteggAuthService(
     private fun isAutoRefreshBlocked(source: RefreshInvocationSource): Boolean {
         return disableAutoRefresh && source == RefreshInvocationSource.INTERNAL_AUTO
     }
+
+    /**
+     * Decides whether an in-flight [refreshIdempotent] call should treat the token as
+     * already refreshed by a *concurrent* caller and skip its own network refresh.
+     *
+     * The signal is **token identity**, not remaining TTL: a caller snapshots the access
+     * token before contending for [refreshMutex]; if, after acquiring the lock, the live
+     * token differs from that snapshot, some other caller refreshed it while we waited and
+     * we can safely skip.
+     *
+     * Keying this off remaining TTL (the previous `calculateTimerOffset() > 0` check) was
+     * the bug: the refresh timer is scheduled at 80% of TTL, so it fires with ~20% of the
+     * TTL still on the clock. For any TTL > 100s that remaining 20% is still > the 20s
+     * refresh floor, so a healthy, not-yet-refreshed token looked "already refreshed" and
+     * the scheduled refresh was skipped — and never rescheduled, since the next timer is
+     * only armed after a real refresh in [sendRefreshTokenInternal]. Auto-refresh died and
+     * the session silently expired.
+     */
+    internal fun wasRefreshedConcurrently(tokenAtRequest: String?, currentToken: String?): Boolean {
+        return tokenAtRequest != null && currentToken != null && tokenAtRequest != currentToken
+    }
     /**
      * Idempotent refresh token with network quality check.
      * Uses a coroutine Mutex so that concurrent callers suspend and wait for the
@@ -444,17 +465,15 @@ class FronteggAuthService(
             Log.d(TAG, "Skipping auto refresh (FRONTEGG_DISABLE_AUTO_REFRESH=true)")
             return false
         }
+        // Snapshot the access token before contending for the mutex, so that after we
+        // acquire it we can tell whether a *concurrent* caller refreshed while we waited
+        // (token changed) versus this being the refresh we were scheduled to perform
+        // (token unchanged). See [wasRefreshedConcurrently] for why identity, not TTL.
+        val tokenAtRequest = accessToken.value
         val success = refreshMutex.withLock {
-            if (!force) {
-                val currentAccessToken = accessToken.value
-                if (currentAccessToken != null) {
-                    val decoded = JWTHelper.decode(currentAccessToken)
-                    val offset = decoded.exp.calculateTimerOffset()
-                    if (offset > 0) {
-                        Log.d(TAG, "refreshIdempotent: token already refreshed by concurrent call, skipping")
-                        return@withLock true
-                    }
-                }
+            if (!force && wasRefreshedConcurrently(tokenAtRequest, accessToken.value)) {
+                Log.d(TAG, "refreshIdempotent: token already refreshed by concurrent call, skipping")
+                return@withLock true
             }
 
             try {

--- a/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
@@ -244,6 +244,92 @@ class FronteggAuthServiceTest {
         assert(result)
     }
 
+    /**
+     * Regression for the token-refresh-timer death (reported by Retail Success — Dev env,
+     * 5-minute token TTL).
+     *
+     * The refresh timer is scheduled at 80% of TTL, so it fires with ~20% of the TTL still
+     * on the clock. The "already refreshed by concurrent call" guard in [refreshIdempotent]
+     * used to key off *remaining TTL* (`calculateTimerOffset() > 0`, i.e. > 20s left) instead
+     * of *token identity*. For any TTL > 100s, 20% of TTL is still > 20s, so the timer mistook
+     * the very token it was scheduled for as a concurrent refresh, skipped the network call,
+     * and — because the next timer is only ever rescheduled inside sendRefreshTokenInternal —
+     * never rescheduled. Auto-refresh died silently and the session expired.
+     *
+     * A 5-minute (300s) token that is NOT changed by anyone else must actually refresh and
+     * reschedule the timer.
+     */
+    @Test
+    fun `auto refresh does not skip a long-TTL token as a phantom concurrent refresh`() = runBlocking {
+        val refreshTokenTimer = mockk<FronteggRefreshTokenTimer>()
+        every { refreshTokenTimer.refreshTokenIfNeeded }.returns(FronteggCallback())
+        every { refreshTokenTimer.cancelLastTimer() }.returns(Unit)
+        every { refreshTokenTimer.scheduleTimer(any()) }.returns(Unit)
+        val appLifecycle = mockk<FronteggAppLifecycle>()
+        every { appLifecycle.startApp }.returns(FronteggCallback())
+        every { appLifecycle.stopApp }.returns(FronteggCallback())
+        auth = FronteggAuthService(
+            credentialManager = credentialManagerMock,
+            appLifecycle = appLifecycle,
+            refreshTokenTimer = refreshTokenTimer,
+            ioDispatcher = Dispatchers.Unconfined,
+            mainDispatcher = Dispatchers.Unconfined,
+            disableAutoRefresh = false
+        )
+
+        auth.accessToken.value = "current-access-token"
+        auth.refreshToken.value = "current-refresh-token"
+        auth.isAuthenticated.value = true
+
+        mockkObject(JWTHelper)
+        val jwt = JWT()
+        jwt.exp = (System.currentTimeMillis() / 1000) + 300 // 5-minute TTL, well above the 100s threshold
+        every { JWTHelper.decode(any()) }.returns(jwt)
+
+        every { NetworkGate.isNetworkLikelyGood(any()) }.returns(true)
+        every { apiMock.evictIdleConnections() }.returns(Unit)
+        every { apiMock.refreshToken("current-refresh-token") }.returns(
+            AuthResponse().apply {
+                access_token = "new-access-token"
+                refresh_token = "new-refresh-token"
+            }
+        )
+        every { apiMock.me() }.returns(mockk<User>(relaxed = true))
+        every { credentialManagerMock.save(any(), any()) }.returns(true)
+
+        val result = auth.refreshTokenAndWaitInternal(
+            source = FronteggAuthService.RefreshInvocationSource.INTERNAL_AUTO
+        )
+
+        assert(result) { "auto refresh must report success, was $result" }
+        // The refresh must hit the network instead of being skipped as a phantom concurrent refresh.
+        verify(exactly = 1) { apiMock.refreshToken("current-refresh-token") }
+        // And the next timer must be scheduled so auto-refresh keeps looping.
+        verify(atLeast = 1) { refreshTokenTimer.scheduleTimer(any()) }
+    }
+
+    @Test
+    fun `wasRefreshedConcurrently is false when the token is unchanged since the refresh was requested`() {
+        // The core of the bug: a token that nobody else touched must NOT be treated as
+        // "already refreshed" — otherwise the scheduled refresh is skipped forever.
+        assert(!auth.wasRefreshedConcurrently("same-token", "same-token"))
+    }
+
+    @Test
+    fun `wasRefreshedConcurrently is true when another caller swapped the token while we waited`() {
+        // Genuine concurrent refresh: the live token differs from the one we snapshotted
+        // before taking the mutex, so we correctly skip our redundant network call.
+        assert(auth.wasRefreshedConcurrently("token-at-request", "token-from-concurrent-refresh"))
+    }
+
+    @Test
+    fun `wasRefreshedConcurrently is false when there was no token to compare against`() {
+        // No baseline (cold start / logged-out) means there is nothing to dedup against;
+        // never skip on a null token.
+        assert(!auth.wasRefreshedConcurrently(null, "any-token"))
+        assert(!auth.wasRefreshedConcurrently("token-at-request", null))
+    }
+
     @Test
     fun `logout should refresh FronteggAuth`() = runBlocking {
         val mockCookieManager = mockkClass(CookieManager::class)


### PR DESCRIPTION
## Problem

Retail Success reported that on their Dev environment (5-minute token TTL), the Android SDK stops refreshing — after ~4 minutes the token silently expires and the user is logged out. The logcat shows the refresh timer firing once, logging `refreshIdempotent: token already refreshed by concurrent call, skipping`, then nothing — **no new timer is ever scheduled.**

## Root cause

`refreshIdempotent`'s "already refreshed by concurrent call" guard used **remaining TTL** as a proxy for "someone else refreshed":

```kotlin
val offset = decoded.exp.calculateTimerOffset()
if (offset > 0) { /* skip */ }   // offset > 0  ⟺  > 20s of TTL left
```

But the refresh timer is scheduled at **80% of TTL**, so it fires with ~20% of the TTL still on the clock. For any token with **TTL > 100s**, that remaining 20% is still above the 20-second refresh floor, so `offset > 0` and the timer mistakes the very token it was scheduled for as a concurrent refresh. It skips the network call **and never reschedules** — the next timer is only armed after a real refresh inside `sendRefreshTokenInternal`. The refresh loop dies.

Only tokens with TTL ≤ 100s ever reached the branch that actually refreshes. Introduced with the `refreshIdempotent` mutex refactor (offline-mode session recovery, FR-24189).

### Logcat, to the millisecond
| Evidence | Value |
|---|---|
| JWT `exp − iat` | 300s (5-min Dev TTL) |
| `Start Timer task` | 238566 ms ≈ 0.8 × remaining |
| `Job started` | ~4 min later, ~59s TTL still left → `offset` ≈ 47s > 0 → guard trips |
| `already refreshed… skipping` → *(no further `Start Timer`)* | refresh loop dead |

## Fix

Dedup on **token identity**, not TTL. Snapshot the access token before contending for `refreshMutex`; skip only if the live token actually *changed* while we waited on the lock (a genuine concurrent refresh). Standard double-checked locking:

```kotlin
val tokenAtRequest = accessToken.value               // before the mutex
refreshMutex.withLock {
    if (!force && wasRefreshedConcurrently(tokenAtRequest, accessToken.value)) { /* skip */ }
    ...
}
```

- A burst of callers all snapshot `T0`; the winner refreshes to `T1`; the rest see `T1 ≠ T0` and correctly skip. Concurrent-refresh de-duplication is preserved.
- `force = true` (tenant switch) still bypasses the guard entirely — unchanged.
- The resume/lifecycle path (`refreshTokenWhenNeeded`) already gated on `offset <= 0` and never relied on the guard as a throttle, so there's no over-refresh.

## Tests

- **Regression test** — drives `refreshIdempotent` end-to-end with a 300s TTL and asserts `api.refreshToken` fires **and** the timer is rescheduled. Verified it fails on the old code (`Api.refreshToken(...) was not called` while `refreshIdempotent` still returns `true` — the silent-failure signature) and passes on the fix.
- **Unit tests** for `wasRefreshedConcurrently`: unchanged token → refresh (the bug), swapped token → skip (dedup preserved), null baseline → never skip.

Full Android unit suite: **601 tests, 0 failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
