### PR TITLE
fix(embedded): drive native step-up to the MFA page (FR-24939)

### DIFF
--- a/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
+++ b/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.View
 import android.widget.LinearLayout
 import com.frontegg.android.embedded.FronteggWebView
+import com.frontegg.android.embedded.StepUpWebDriver
 import com.frontegg.android.exceptions.CanceledByUserException
 import com.frontegg.android.services.FronteggInnerStorage
 import com.frontegg.android.services.FronteggState
@@ -143,6 +144,15 @@ class EmbeddedAuthActivity : FronteggBaseActivity() {
                 return
             }
             webViewUrl = url
+
+            // FR-24939: a native step-up authorize URL bootstraps the box on its prelogin
+            // path and never reaches the step-up route on its own, so the box renders blank
+            // instead of the MFA challenge. Install the document-start driver that routes it
+            // to the step-up page (see StepUpWebDriver). Registered before any loadUrl and
+            // gated to the step-up flow so normal login is untouched.
+            if (fronteggAuth.isStepUpAuthorization.value && url.contains("acr_values")) {
+                StepUpWebDriver.install(webView, url)
+            }
         } else if (directLoginLaunched) {
             val type = intent.extras!!.getString(DIRECT_LOGIN_ACTION_TYPE)
             val data = intent.extras!!.getString(DIRECT_LOGIN_ACTION_DATA)

--- a/android/src/main/java/com/frontegg/android/embedded/StepUpWebDriver.kt
+++ b/android/src/main/java/com/frontegg/android/embedded/StepUpWebDriver.kt
@@ -1,0 +1,116 @@
+package com.frontegg.android.embedded
+
+import android.net.Uri
+import android.util.Log
+import android.webkit.WebView
+import androidx.webkit.JavaScriptReplyProxy
+import androidx.webkit.WebMessageCompat
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
+import org.json.JSONObject
+
+/**
+ * FR-24939 — native-side step-up routing for the embedded login WebView.
+ *
+ * The hosted-login box renders its step-up (MFA) page only when the WebView is at the
+ * step-up route with the native token bridge present. A native step-up authorize URL
+ * (`acr_values` + `max_age`), however, bootstraps the box on its prelogin path and never
+ * navigates to that route on its own — it is silently token-refreshed and the box renders
+ * a blank page instead of the MFA challenge.
+ *
+ * This driver bridges that gap from the native side. While presenting a step-up flow it
+ * injects a document-start script that, before the box reads the document:
+ *   1. seeds the box's step-up `localStorage` contract (`SHOULD_STEP_UP`,
+ *      `FRONTEGG_OAUTH_STEP_UP_MAX_AGE`),
+ *   2. rewrites the URL to the box's step-up route so it renders the MFA challenge, and
+ *   3. points the box's after-auth redirect (`FRONTEGG_AFTER_AUTH_REDIRECT_URL`) back at
+ *      the original authorize URL.
+ *
+ * When step-up completes, the box performs a full navigation to that authorize URL — now
+ * with an elevated session — which yields an elevated `code` that the existing OAuth
+ * callback interception in [FronteggWebClient] exchanges into a stepped-up token. No new
+ * native token-capture path is required.
+ *
+ * Android counterpart of iOS `StepUpWebDriver` (WKUserScript at `.atDocumentStart`).
+ */
+object StepUpWebDriver {
+    private val TAG = StepUpWebDriver::class.java.simpleName
+
+    /** JS object name the driver posts its native log line to (see [addWebMessageListener]). */
+    private const val MESSAGE_CHANNEL = "FronteggStepUpDriver"
+
+    /**
+     * Registers the document-start driver script for a step-up authorize URL. No-op (with a
+     * warning) on legacy WebViews without [WebViewFeature.DOCUMENT_START_SCRIPT] — the same
+     * capability gate the Admin Portal bridge uses.
+     */
+    fun install(webView: WebView, authorizeUrl: String) {
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)) {
+            Log.w(TAG, "DOCUMENT_START_SCRIPT unsupported; step-up driver not installed")
+            return
+        }
+
+        // Surface the driver's outcome into logcat — the box JS console is invisible in
+        // release (webContentsDebugging is off), so this makes the routing observable.
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+            WebViewCompat.addWebMessageListener(
+                webView, MESSAGE_CHANNEL, setOf("*")
+            ) { _: WebView, message: WebMessageCompat, _: Uri, _: Boolean, _: JavaScriptReplyProxy ->
+                Log.i(TAG, "[step-up] ${message.data}")
+            }
+        }
+
+        WebViewCompat.addDocumentStartJavaScript(webView, script(authorizeUrl), setOf("*"))
+    }
+
+    /** Builds the document-start script for the given original step-up authorize URL. */
+    fun script(authorizeUrl: String): String {
+        // JSON-quote yields a safely-escaped JS string literal (quotes included).
+        val afterAuth = JSONObject.quote(authorizeUrl)
+        return """
+        (function () {
+          function report(m) {
+            try { $MESSAGE_CHANNEL.postMessage(String(m)); } catch (e) {}
+          }
+          try {
+            var loc = window.location;
+            // Already on the step-up route (e.g. the box's own redirect) — nothing to do.
+            if (loc.pathname.indexOf('/account/step-up') !== -1) { return; }
+            var params = new URLSearchParams(loc.search);
+            // Only act on the step-up authorize/prelogin document.
+            if (!params.get('acr_values')) { return; }
+
+            var rawMaxAge = params.get('max_age');
+            var maxAge = null;
+            if (rawMaxAge != null) {
+              var parsed = parseInt(parseFloat(rawMaxAge), 10);
+              if (!isNaN(parsed)) { maxAge = String(parsed); }
+            }
+
+            var ls = window.localStorage;
+            ls.setItem('SHOULD_STEP_UP', 'true');
+            if (maxAge) { ls.setItem('FRONTEGG_OAUTH_STEP_UP_MAX_AGE', maxAge); }
+            // Absolute http(s) URL => the box treats the post-MFA redirect as a full
+            // navigation, re-hitting /oauth/authorize with the now-elevated session so a
+            // stepped-up code is issued and captured by the native OAuth callback.
+            ls.setItem('FRONTEGG_AFTER_AUTH_REDIRECT_URL', $afterAuth);
+
+            // Hosted-login basename = current path minus its last segment
+            // (e.g. '/oauth' from '/oauth/prelogin'); step-up route is
+            // '<basename>/account/step-up'. Preserve the existing query params and add
+            // the 'maxAge' param the step-up page reads (distinct from OAuth 'max_age').
+            var path = loc.pathname;
+            var basename = path.substring(0, path.lastIndexOf('/'));
+            var search = loc.search || '';
+            if (maxAge) { search += (search ? '&' : '?') + 'maxAge=' + maxAge; }
+            var target = basename + '/account/step-up' + search;
+
+            window.history.replaceState(null, '', loc.origin + target);
+            report('routed to ' + basename + '/account/step-up (maxAge=' + maxAge + ')');
+          } catch (e) {
+            report('error: ' + (e && e.message ? e.message : e));
+          }
+        })();
+        """.trimIndent()
+    }
+}

--- a/android/src/test/java/com/frontegg/android/embedded/StepUpWebDriverTest.kt
+++ b/android/src/test/java/com/frontegg/android/embedded/StepUpWebDriverTest.kt
@@ -1,0 +1,44 @@
+package com.frontegg.android.embedded
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StepUpWebDriverTest {
+
+    private val authorizeUrl =
+        "https://base.url.com/oauth/authorize?response_type=code&acr_values=http" +
+            "%3A%2F%2Fschemas.openid.net%2Fpape%2Fpolicies%2F2007%2F06%2Fmulti-factor&max_age=60"
+
+    @Test
+    fun `script seeds the step-up localStorage contract and rewrites to the step-up route`() {
+        val script = StepUpWebDriver.script(authorizeUrl)
+
+        // Only acts on the step-up authorize document.
+        assertTrue(script.contains("acr_values"))
+        // Step-up localStorage contract the box reads.
+        assertTrue(script.contains("SHOULD_STEP_UP"))
+        assertTrue(script.contains("FRONTEGG_OAUTH_STEP_UP_MAX_AGE"))
+        assertTrue(script.contains("FRONTEGG_AFTER_AUTH_REDIRECT_URL"))
+        // Routes the box to its step-up page before it reads the URL.
+        assertTrue(script.contains("/account/step-up"))
+        assertTrue(script.contains("replaceState"))
+    }
+
+    @Test
+    fun `script embeds the authorize URL as a safely-escaped JS string literal`() {
+        // A URL carrying characters that would break a naive string literal.
+        val hostile = "https://x.com/oauth/authorize?a=\"b\"\\c</script>"
+        val script = StepUpWebDriver.script(hostile)
+
+        // The URL must appear only in its JSON-quoted (escaped) form, never raw —
+        // otherwise a crafted authorize URL could break out of the literal.
+        val quoted = JSONObject.quote(hostile)
+        assertTrue("expected escaped literal $quoted in script", script.contains(quoted))
+        assertFalse("raw unescaped URL must not leak into the script", script.contains("=\"b\"\\c"))
+    }
+}

--- a/embedded/e2e/scenario-catalog.json
+++ b/embedded/e2e/scenario-catalog.json
@@ -19,6 +19,12 @@
       "class": "com.frontegg.demo.e2e.EmbeddedE2ETests"
     },
     {
+      "method": "testEmbeddedStepUpMfaChallenge",
+      "title": "Embedded step-up routes to the MFA challenge",
+      "description": "Logs in, starts a native step-up (acr_values + max_age), and verifies the StepUpWebDriver seeds the box's step-up localStorage contract and rewrites the URL to the /account/step-up route so the hosted box renders its MFA challenge instead of a blank page, then completes the challenge and verifies the app reports step-up success.",
+      "class": "com.frontegg.demo.e2e.EmbeddedE2ETests"
+    },
+    {
       "method": "testRequestAuthorizeFlow",
       "title": "Request authorize flow signs in seeded user",
       "description": "Seeds the request-authorize token, starts the authorize flow, and verifies the seeded signup user is authenticated.",

--- a/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETestCase.kt
+++ b/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETestCase.kt
@@ -768,6 +768,27 @@ open class EmbeddedE2ETestCase {
         clickWebElement("e2e-mfa-submit")
     }
 
+    /**
+     * Poll the SDK WebView for the step-up stub's challenge button (mirrors [verifyMfaPage]).
+     * The stub renders #e2e-stepup-complete ONLY when the native StepUpWebDriver honored its
+     * contract (seeded SHOULD_STEP_UP and replaceState'd the path to /account/step-up), so a
+     * timeout here means the driver did not inject/route — the production blank-page bug.
+     */
+    protected fun waitForStepUpChallenge(timeoutMs: Long = 30_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                authWebView().withElement(findElement(Locator.ID, "e2e-stepup-complete"))
+                return
+            } catch (_: Throwable) {
+                Thread.sleep(2_000)
+            }
+        }
+        throw AssertionError(
+            "Step-up MFA challenge not rendered (#e2e-stepup-complete absent) — driver contract not honored",
+        )
+    }
+
     /** Verify an error message is visible in the WebView or accessibility tree. */
     protected fun verifyErrorMessage(expectedText: String) {
         if (waitForTextOrDescContains(expectedText, 15_000)) return

--- a/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETests.kt
+++ b/embedded/src/androidTest/java/com/frontegg/demo/e2e/EmbeddedE2ETests.kt
@@ -49,6 +49,44 @@ class EmbeddedE2ETests : EmbeddedE2ETestCase() {
     }
 
     @Test
+    fun testEmbeddedStepUpMfaChallenge() {
+        // Reach the authenticated Home screen via the embedded password flow.
+        launchApp(resetState = true)
+        loginWithPassword()
+        waitForUserEmail("test@frontegg.com", timeoutMs = 120_000)
+        val tokenExchangesBeforeStepUp = mock.requestCount("POST", "/oauth/token")
+
+        // Trigger a native step-up (acr_values + max_age). The embedded box bootstraps on its
+        // prelogin path; the native StepUpWebDriver must route it to /account/step-up so the
+        // (fixed) box renders the MFA challenge instead of a blank page.
+        tapDesc("Sensitive action")
+
+        // The step-up stub injects #e2e-stepup-complete ONLY when the driver seeded
+        // SHOULD_STEP_UP and rewrote the path to /account/step-up — so this fails if the driver
+        // did not inject/route (the production blank-page bug).
+        device.wait(Until.hasObject(By.clazz("android.webkit.WebView")), 30_000)
+        waitForStepUpChallenge()
+
+        // Completing the challenge navigates to the driver-seeded after-auth authorize URL, which
+        // issues an elevated code that the existing OAuth callback exchanges for a token.
+        clickWebElement("e2e-stepup-complete")
+
+        // Definitive success signal: the elevated authorization code is exchanged for a token
+        // (only reachable because the driver drove the stub challenge and seeded the after-auth
+        // redirect), and the step-up activity tears down back to the authenticated profile.
+        val exchangeDeadline = System.currentTimeMillis() + 60_000
+        while (mock.requestCount("POST", "/oauth/token") <= tokenExchangesBeforeStepUp &&
+            System.currentTimeMillis() < exchangeDeadline
+        ) {
+            Thread.sleep(500)
+        }
+        if (mock.requestCount("POST", "/oauth/token") <= tokenExchangesBeforeStepUp) {
+            throw AssertionError("Expected the elevated step-up code to be exchanged for a token")
+        }
+        waitForDesc("UserPageRoot", 120_000)
+    }
+
+    @Test
     fun testRequestAuthorizeFlow() {
         launchApp(resetState = true)
         waitForDesc("LoginPageRoot", 120_000)

--- a/embedded/src/androidTest/java/com/frontegg/demo/e2e/LocalMockAuthServer.kt
+++ b/embedded/src/androidTest/java/com/frontegg/demo/e2e/LocalMockAuthServer.kt
@@ -339,6 +339,29 @@ class LocalMockAuthServer {
             </script>"""
             return html(200, ti, htmlBody)
         }
+
+        // FR-24939 step-up: a native step-up authorize URL carries acr_values (+ max_age).
+        val acr = fq(q, "acr_values")
+        if (acr.isNotEmpty()) {
+            // Second pass — the mock MFA challenge completed (the stub navigated back to this
+            // authorize URL with stepUpCompleted=1). Issue an elevated code and hand it to the
+            // existing OAuth callback, exactly like the browser/password flows. The original
+            // `state` is echoed so the SDK matches its registered pending step-up request.
+            if (fq(q, "stepUpCompleted") == "1") {
+                val code = state.issueCode("test@frontegg.com", redirect, st)
+                return redir(cb(redirect, code, st))
+            }
+            // First pass — 302 to prelogin, carrying acr_values (+ max_age) so the native
+            // StepUpWebDriver's document-start guard fires on the prelogin document and routes
+            // the box to its /account/step-up page.
+            val maxAge = fq(q, "max_age")
+            val stepUpHs = state.issueHosted(redirect, st, hint)
+            val stepUpLoc = "${urlRoot()}/oauth/prelogin?" +
+                "client_id=${enc(cid)}&redirect_uri=${enc(redirect)}&state=${enc(stepUpHs)}&acr_values=${enc(acr)}" +
+                if (maxAge.isNotEmpty()) "&max_age=${enc(maxAge)}" else ""
+            return redir(stepUpLoc)
+        }
+
         val hs = state.issueHosted(redirect, st, hint)
         val loc = "${urlRoot()}/oauth/prelogin?" +
             "client_id=${enc(cid)}&redirect_uri=${enc(redirect)}&state=${enc(hs)}" +
@@ -349,6 +372,12 @@ class LocalMockAuthServer {
     private fun hostedPrelogin(q: Map<String, List<String>>): MockResponse {
         val hs = fq(q, "state")
         val ctx = state.hosted(hs) ?: return html(400, "err", "<h1>Invalid</h1>")
+        // FR-24939 step-up: the box bootstraps here for a step-up authorize. Serve a step-up
+        // aware stub that stands in for the (fixed) hosted box — it renders its MFA challenge
+        // ONLY when the native StepUpWebDriver has seeded SHOULD_STEP_UP and rewritten the path
+        // to /account/step-up. A driver that failed to inject leaves the page blank, exactly
+        // reproducing the production bug this driver fixes.
+        if (fq(q, "acr_values").isNotEmpty()) return stepUpPreloginStub()
         var email = fq(q, "email", ctx.loginHint)
         if (email.isEmpty()) {
             val b =
@@ -402,6 +431,43 @@ class LocalMockAuthServer {
             body:JSON.stringify({state:'${hs}',token:j.access_token})});
             if(!p.ok)return;await p.json();location='/oauth/postlogin/redirect?state=${enc(hs)}';};</script>"""
         return html(200, "pwd", b)
+    }
+
+    /**
+     * FR-24939 step-up stub — the offline stand-in for the fixed hosted box's step-up (MFA) page.
+     * The native StepUpWebDriver's document-start script runs BEFORE this page's script: it seeds
+     * localStorage (SHOULD_STEP_UP, FRONTEGG_OAUTH_STEP_UP_MAX_AGE, FRONTEGG_AFTER_AUTH_REDIRECT_URL)
+     * and history.replaceState's the path to /account/step-up. This page injects its MFA challenge
+     * (#e2e-stepup-complete) ONLY when that contract is honored; otherwise the root stays empty and
+     * the E2E fails — the very blank-page bug the driver fixes. The Complete button navigates to the
+     * driver-seeded after-auth authorize URL with stepUpCompleted=1 to elevate the session.
+     */
+    private fun stepUpPreloginStub(): MockResponse {
+        val b = """
+            <div id="e2e-stepup-root"></div>
+            <p id="e2e-stepup-fallback">Loading…</p>
+            <script>
+            (function () {
+              var ls = window.localStorage;
+              var routed = ls.getItem('SHOULD_STEP_UP') === 'true'
+                        && window.location.pathname.indexOf('/account/step-up') !== -1;
+              if (!routed) { return; }
+              var after = ls.getItem('FRONTEGG_AFTER_AUTH_REDIRECT_URL');
+              var root = document.getElementById('e2e-stepup-root');
+              root.innerHTML =
+                '<h1 id="e2e-stepup-title">Step-Up MFA Mock</h1>' +
+                '<button id="e2e-stepup-complete" type="button">Complete Step-Up</button>';
+              var fb = document.getElementById('e2e-stepup-fallback');
+              if (fb) { fb.parentNode.removeChild(fb); }
+              document.getElementById('e2e-stepup-complete').addEventListener('click', function () {
+                if (!after) { return; }
+                var sep = after.indexOf('?') !== -1 ? '&' : '?';
+                window.location.href = after + sep + 'stepUpCompleted=1';
+              });
+            })();
+            </script>
+        """.trimIndent()
+        return html(200, "step-up", b)
     }
 
     private fun providerPage(title: String, buttonText: String, hs: String, email: String): MockResponse {


### PR DESCRIPTION
## Problem

Even with the native token bridge and the hosted-login box's step-up render fix ([admin-box#2865](https://github.com/frontegg/admin-box/pull/2865), deployed in 7.118.0), a native step-up still renders a **blank page instead of the MFA challenge**.

**Root cause:** the box renders its step-up page (`StepUpPage`) only when the WebView is *at* the step-up route (`/oauth/account/step-up`) with the native token bridge present. A native step-up authorize URL (`acr_values` + `max_age`) instead bootstraps the box on its **prelogin** path and never navigates to that route on its own — it is silently token-refreshed and the box renders blank. Nothing routes the WebView onward to `/oauth/account/step-up`.

This is the Android counterpart of [frontegg-ios-swift#278](https://github.com/frontegg/frontegg-ios-swift/pull/278).

## Fix

New `StepUpWebDriver` (`embedded/StepUpWebDriver.kt`): while presenting a step-up flow, inject a **document-start** script that, before the box reads the document:
- seeds the box's step-up `localStorage` contract (`SHOULD_STEP_UP`, `FRONTEGG_OAUTH_STEP_UP_MAX_AGE`),
- rewrites the URL to the box's step-up route (`<basename>/account/step-up`) so the box renders `StepUpPage`, and
- points the box's after-auth redirect (`FRONTEGG_AFTER_AUTH_REDIRECT_URL`) back at the original authorize URL.

On completion the box performs a full navigation to that authorize URL — now with an elevated session — yielding a stepped-up `code` that the existing `FronteggWebClient` OAuth callback already captures. No new native token-capture path is required.

Wiring (`EmbeddedAuthActivity.consumeIntent`): the driver is installed right after the step-up `AUTHORIZE_URI` is read, **before any `loadUrl`**, and gated on `isStepUpAuthorization && url.contains("acr_values")` so normal login is untouched.

Notes:
- Uses `WebViewCompat.addDocumentStartJavaScript` behind the `DOCUMENT_START_SCRIPT` feature gate — the same mechanism (and legacy-fallback shape) as the Admin Portal bridge in `AdminPortalActivity`. The Android equivalent of iOS's `WKUserScript` at `.atDocumentStart`.
- The authorize URL is embedded as a JSON-quoted JS string literal, so a crafted URL cannot break out of the script (unit-tested).
- **No `max_age` change needed** here — Android already emits integer seconds (`Duration.inWholeSeconds`); the `60.0` float bug was iOS-specific.
- A minimal `[step-up] routed…` line is surfaced to logcat via a `WebMessageListener` (same pattern as the passkey listener), since the box JS console is invisible in release.

## Verification

- ✅ `:android:compileDebugKotlin` → **BUILD SUCCESSFUL**.
- ✅ `:android:testDebugUnitTest` → new **`StepUpWebDriverTest`** (2/2 — contract keys + URL-escaping), and existing **`StepUpAuthenticatorTest`** (7/7) and **`AuthorizeUrlGeneratorTest`** (16/16) still green.
- ✅ `:android:detekt` → **BUILD SUCCESSFUL**.
- ⏳ On-device E2E (blank page → MFA challenge) still to run on an emulator; the iOS counterpart (#278) is verified on-device against the deployed box, and this mirrors that logic.

**Requires** the box-side render fix ([admin-box#2865](https://github.com/frontegg/admin-box/pull/2865), deployed in 7.118.0): the driver routes the WebView to the step-up route; #2865 is what renders `StepUpPage` there. Both halves are needed.

Relates to **FR-24939**.
