### PR TITLE
fix(pkce): use RFC 7636-compliant code-verifier length (FR-25933)

### DIFF
--- a/android/src/main/java/com/frontegg/android/utils/AuthorizeUrlGenerator.kt
+++ b/android/src/main/java/com/frontegg/android/utils/AuthorizeUrlGenerator.kt
@@ -15,6 +15,10 @@ class AuthorizeUrlGenerator(
 ) {
     companion object {
         private val TAG = AuthorizeUrlGenerator::class.java.simpleName
+
+        // PKCE code-verifier length. RFC 7636 §4.1 allows 43–128 characters;
+        // 64 gives a comfortable ~380 bits of entropy over the 62-char alphabet.
+        private const val CODE_VERIFIER_LENGTH = 64
     }
 
     private var storage = StorageProvider.getInnerStorage()
@@ -75,7 +79,8 @@ class AuthorizeUrlGenerator(
         val codeVerifier: String = if (preserveCodeVerifier == true) {
             credentialManager.getCodeVerifier()!!
         } else {
-            val code = createRandomString()
+            // RFC 7636 §4.1 requires a 43–128 character code verifier.
+            val code = createRandomString(CODE_VERIFIER_LENGTH)
             credentialManager.saveCodeVerifier(code)
             code
         }

--- a/android/src/test/java/com/frontegg/android/utils/AuthorizeUrlGeneratorTest.kt
+++ b/android/src/test/java/com/frontegg/android/utils/AuthorizeUrlGeneratorTest.kt
@@ -209,4 +209,13 @@ class AuthorizeUrlGeneratorTest {
 
         verify { credentialManager.saveCodeVerifier(any()) }
     }
+
+    @Test
+    fun `code verifier length should comply with RFC 7636 (43 to 128 chars)`() {
+        val (_, codeVerifier) = authorizeUrlGenerator.generate()
+
+        assert(codeVerifier.length in 43..128) {
+            "PKCE code_verifier must be 43-128 characters per RFC 7636 §4.1, was ${codeVerifier.length}"
+        }
+    }
 }


### PR DESCRIPTION
## Problem (FR-25933)

`AuthorizeUrlGenerator.createRandomString(length: Int = 16)` was used to build the PKCE **code verifier**, producing a 16-character string. RFC 7636 §4.1 mandates a verifier of **43–128 characters**.

**Impact:** non-compliant and materially weaker than spec (~95 bits). A stricter/updated authorization server or a pen-test/security review can reject it, breaking all logins.

## Fix

Generate the code verifier at **64 characters** (~380 bits over the 62-char alphabet), via a named `CODE_VERIFIER_LENGTH` constant. Nonce generation is unaffected.

## Tests

`AuthorizeUrlGeneratorTest`: new `code verifier length should comply with RFC 7636 (43 to 128 chars)` — asserts the returned verifier is in `43..128`. Failed RED at 16 chars, passes at 64. Full `:android` unit-test suite green.