### PR TITLE
fix(auth): offload blocking network off the caller's thread (FR-25932)

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -633,10 +633,14 @@ class FronteggAuthService(
             Log.d(TAG, "Skipping auto refresh (FRONTEGG_DISABLE_AUTO_REFRESH=true)")
             return false
         }
-        if (!isNetworkGoodSync()) {
-            if (enableOfflineMode) {
-                setOfflineMode(true)
-                bgScope.launch {
+        // The network-quality probe (isNetworkGoodSync -> NetworkGate) performs blocking
+        // OkHttp I/O. Run the whole decision on the background dispatcher so this method
+        // honours its "returns immediately" contract and never throws
+        // NetworkOnMainThreadException when called from the main thread (FR-25932).
+        bgScope.launch {
+            if (!isNetworkGoodSync()) {
+                if (enableOfflineMode) {
+                    setOfflineMode(true)
                     requestQueue.enqueue(
                         requestId = "refresh_token_${System.currentTimeMillis()}",
                         request = {
@@ -649,13 +653,9 @@ class FronteggAuthService(
                     )
                     startNetworkMonitoring()
                 }
-                return true
+                return@launch
             }
-            return false
-        }
-        setOfflineMode(false)
-
-        bgScope.launch {
+            setOfflineMode(false)
             refreshIdempotent(source = source)
         }
 
@@ -1130,7 +1130,12 @@ class FronteggAuthService(
         if (accessToken.isBlank() || refreshToken.isBlank()) {
             throw IllegalArgumentException("Access token and refresh token must not be blank")
         }
-        setCredentials(accessToken, refreshToken)
+        // setCredentials performs blocking network (api.me()); offload it so this does not
+        // run network on the caller's thread and crash with NetworkOnMainThreadException
+        // (FR-25932). Blank-token validation above stays synchronous.
+        bgScope.launch {
+            setCredentials(accessToken, refreshToken)
+        }
     }
 
     override fun getSessionStartTime(): Long {

--- a/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/FronteggAuthServiceTest.kt
@@ -21,6 +21,7 @@ import com.frontegg.android.models.User
 import com.frontegg.android.models.WebAuthnAssertionRequest
 import com.frontegg.android.models.WebAuthnRegistrationRequest
 import com.frontegg.android.testUtils.BlockCoroutineDispatcher
+import com.frontegg.android.testUtils.QueueingCoroutineDispatcher
 import com.frontegg.android.utils.AuthorizeUrlGenerator
 import com.frontegg.android.utils.CredentialKeys
 import com.frontegg.android.utils.FronteggCallback
@@ -1433,5 +1434,74 @@ class FronteggAuthServiceTest {
         assert(auth.accessToken.value == "access-token-for-B") {
             "accessToken.value should be the freshly-minted token for tenant-B, was ${auth.accessToken.value}"
         }
+    }
+
+    private fun buildAuthWith(dispatcher: kotlinx.coroutines.CoroutineDispatcher): FronteggAuthService {
+        val refreshTokenTimer = mockk<FronteggRefreshTokenTimer>()
+        every { refreshTokenTimer.refreshTokenIfNeeded }.returns(FronteggCallback())
+        every { refreshTokenTimer.cancelLastTimer() }.returns(Unit)
+        every { refreshTokenTimer.scheduleTimer(any()) }.returns(Unit)
+        val appLifecycle = mockk<FronteggAppLifecycle>()
+        every { appLifecycle.startApp }.returns(FronteggCallback())
+        every { appLifecycle.stopApp }.returns(FronteggCallback())
+        return FronteggAuthService(
+            credentialManager = credentialManagerMock,
+            appLifecycle = appLifecycle,
+            refreshTokenTimer = refreshTokenTimer,
+            ioDispatcher = dispatcher,
+            mainDispatcher = dispatcher,
+            disableAutoRefresh = false
+        )
+    }
+
+    /**
+     * FR-25932: refreshTokenIfNeeded() is documented as "returns immediately" but used to
+     * run NetworkGate's blocking OkHttp ping synchronously on the caller's thread — a
+     * NetworkOnMainThreadException / crash when called from the main thread. The blocking
+     * network work must be offloaded to the background dispatcher.
+     */
+    @Test
+    fun `refreshTokenIfNeeded does not touch the network on the calling thread`() {
+        val dispatcher = QueueingCoroutineDispatcher()
+        val auth = buildAuthWith(dispatcher)
+        dispatcher.clearQueue() // drop construction-time launches
+
+        every { NetworkGate.isNetworkLikelyGood(any()) }.returns(true)
+        every { apiMock.refreshToken(any()) }.returns(authResponse)
+        every { apiMock.me() }.returns(mockk<User>(relaxed = true))
+        every { credentialManagerMock.save(any(), any()) }.returns(true)
+        every { credentialManagerMock.save(any(), any(), any()) }.returns(true)
+
+        val result = auth.refreshTokenIfNeeded()
+
+        // Contract preserved: a refresh was scheduled.
+        assert(result)
+        // The blocking network-quality check must NOT have run on this (calling) thread...
+        verify(exactly = 0) { NetworkGate.isNetworkLikelyGood(any()) }
+        // ...it must have been offloaded to the background dispatcher instead.
+        assert(dispatcher.size >= 1) { "expected blocking work to be dispatched to background, queue was empty" }
+    }
+
+    /**
+     * FR-25932: updateCredentials() -> setCredentials() called api.me() (blocking OkHttp
+     * .execute()) inline on the caller's thread. It must be offloaded, while blank-token
+     * validation stays synchronous.
+     */
+    @Test
+    fun `updateCredentials does not call api_me on the calling thread`() {
+        val dispatcher = QueueingCoroutineDispatcher()
+        val auth = buildAuthWith(dispatcher)
+        dispatcher.clearQueue() // drop construction-time launches
+
+        every { credentialManagerMock.save(any(), any()) }.returns(true)
+        every { credentialManagerMock.save(any(), any(), any()) }.returns(true)
+        every { apiMock.me() }.returns(mockk<User>(relaxed = true))
+
+        auth.updateCredentials("valid-access-token", "valid-refresh-token")
+
+        // The blocking api.me() call must NOT have run on this (calling) thread...
+        verify(exactly = 0) { apiMock.me() }
+        // ...it must have been offloaded to the background dispatcher instead.
+        assert(dispatcher.size >= 1) { "expected blocking work to be dispatched to background, queue was empty" }
     }
 }

--- a/android/src/test/java/com/frontegg/android/testUtils/QueueingCoroutineDispatcher.kt
+++ b/android/src/test/java/com/frontegg/android/testUtils/QueueingCoroutineDispatcher.kt
@@ -1,0 +1,35 @@
+package com.frontegg.android.testUtils
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A dispatcher that captures dispatched work instead of running it inline, so a
+ * test can assert what has (and has not) executed at the moment a method returns,
+ * then release the queued work on demand.
+ *
+ * The opposite of [BlockCoroutineDispatcher] (which runs everything inline). Used
+ * to prove that blocking work is offloaded to a background dispatcher rather than
+ * executed on the caller's thread.
+ */
+class QueueingCoroutineDispatcher : CoroutineDispatcher() {
+    private val queue = ArrayDeque<Runnable>()
+
+    val size: Int get() = queue.size
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        queue.addLast(block)
+    }
+
+    /** Drops any queued work without running it (e.g. construction-time launches). */
+    fun clearQueue() {
+        queue.clear()
+    }
+
+    /** Runs all queued work, including anything queued while draining. */
+    fun runQueued() {
+        while (queue.isNotEmpty()) {
+            queue.removeFirst().run()
+        }
+    }
+}


### PR DESCRIPTION
## Problem (FR-25932)

Two public methods ran synchronous network work **before** any coroutine launched, so calling them from the main thread (natural, given the "returns immediately" contract) throws `NetworkOnMainThreadException` and crashes:

- `refreshTokenIfNeeded()` → `refreshTokenIfNeededInternal` → `isNetworkGoodSync()` → `NetworkGate.performPingTest()` runs a synchronous OkHttp `.execute()` HEAD inline.
- `updateCredentials()` → `setCredentials` calls `api.me()` (`.execute()`) inline.

## Fix

Offload the blocking work to the background dispatcher, keeping the public contract non-blocking:

- `refreshTokenIfNeededInternal`: the cheap `isAutoRefreshBlocked` guard stays synchronous; the network-quality probe and refresh dispatch move inside `bgScope.launch`. Still returns immediately with `true` (a refresh attempt is scheduled), per the "true if a refresh was started or already in progress" KDoc.
- `updateCredentials`: blank-token validation stays synchronous (still throws `IllegalArgumentException`); `setCredentials` is offloaded to `bgScope.launch`.

## Tests

New `QueueingCoroutineDispatcher` test util (captures dispatched work instead of running it inline). Two new `FronteggAuthServiceTest` cases assert that, at the moment each method returns, the blocking call (`NetworkGate.isNetworkLikelyGood` / `api.me()`) has **not** run on the calling thread and the work was dispatched to the background. Both failed RED on the pre-fix inline calls. Full `:android` unit-test suite green.