### PR TITLE
fix(bridge): same-origin gate on all bridge methods; stop logging raw bodies (FR-25935)

### DIFF
--- a/android/src/main/java/com/frontegg/android/embedded/FronteggNativeBridge.kt
+++ b/android/src/main/java/com/frontegg/android/embedded/FronteggNativeBridge.kt
@@ -26,8 +26,23 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
         return webClient?.getFormAction() ?: "login"
     }
 
+    /**
+     * Same-origin gate for the @JavascriptInterface methods (FR-25935). The bridge is
+     * injected for every page load, so only content served from the Frontegg base URL may
+     * drive native login/SSO/social intents or the loader. If the WebView is navigated or
+     * redirected elsewhere, its scripts must not reach these methods.
+     */
+    private fun isFromTrustedOrigin(action: String): Boolean {
+        val trusted = isTrustedOrigin(webClient?.currentUrlMainSafe(), context.fronteggAuth.baseUrl)
+        if (!trusted) {
+            Log.e("FronteggNativeBridge", "$action refused — untrusted origin")
+        }
+        return trusted
+    }
+
     @JavascriptInterface
     fun loginWithSSO(email: String) {
+        if (!isFromTrustedOrigin("loginWithSSO")) return
         Log.d("FronteggNativeBridge", "loginWithSSO(${email})")
         val generatedUrl = AuthorizeUrlGenerator(context).generate(email)
         val authorizationUrl = Uri.parse(generatedUrl.first)
@@ -160,6 +175,7 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
     @JavascriptInterface
     @Suppress("UNUSED")
     fun loginWithSocialLogin(socialLoginUrl: String) {
+        if (!isFromTrustedOrigin("loginWithSocialLogin")) return
         Log.d("FronteggNativeBridge", "loginWithSocialLogin(${socialLoginUrl})")
 
         val directLogin: Map<String, Any> = mapOf(
@@ -173,6 +189,7 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
     @JavascriptInterface
     @Suppress("UNUSED")
     fun loginWithSocialLoginProvider(provider: String) {
+        if (!isFromTrustedOrigin("loginWithSocialLoginProvider")) return
         Log.d("FronteggNativeBridge", "loginWithSocialLoginProvider(${provider})")
 
         val formAction = getFormAction()
@@ -242,6 +259,7 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
     @JavascriptInterface
     @Suppress("UNUSED")
     fun loginWithCustomSocialLoginProvider(provider: String) {
+        if (!isFromTrustedOrigin("loginWithCustomSocialLoginProvider")) return
         Log.d("FronteggNativeBridge", "loginWithCustomSocialLoginProvider(${provider})")
 
         val formAction = getFormAction()
@@ -256,6 +274,7 @@ class FronteggNativeBridge(val context: Context, private val webClient: Frontegg
 
     @JavascriptInterface
     fun setLoading(value: Boolean) {
+        if (!isFromTrustedOrigin("setLoading")) return
         Log.d("FronteggNativeBridge", "setLoading(${if (value) "true" else "false"})")
         FronteggState.webLoading.value = value
     }

--- a/android/src/main/java/com/frontegg/android/services/Api.kt
+++ b/android/src/main/java/com/frontegg/android/services/Api.kt
@@ -2,6 +2,7 @@ package com.frontegg.android.services
 
 import kotlin.jvm.Throws
 import android.util.Log
+import com.frontegg.android.BuildConfig
 import com.frontegg.android.exceptions.CookieNotFoundException
 import com.frontegg.android.exceptions.FailedToAuthenticateException
 import com.frontegg.android.exceptions.FailedToAuthenticatePasskeysException
@@ -322,30 +323,32 @@ open class Api(
             // everything needed to make an actual entitlement decision (FR-24821).
             val context = com.frontegg.android.entitlements.UserEntitlementsParser.parse(json)
 
-            // Diagnostic logging — full RAW response body. Tagged `[ENT-DEBUG]` so
-            // it's easy to filter logcat for entitlement diagnostics while
-            // triaging FR-24821-style "verdict doesn't match web" reports.
-            Log.i(TAG, "[ENT-DEBUG] RAW /user-entitlements response: $body")
-            Log.i(
-                TAG,
-                "[ENT-DEBUG] Parsed context — features: ${context.features.size}, plans: ${context.plans.size}, permissions: ${context.permissions.size}"
-            )
-            for ((key, detail) in context.features) {
-                val planIdsStr = if (detail.planIds.isEmpty()) "[]" else "[${detail.planIds.joinToString(",")}]"
-                val expireStr = detail.expireTime?.toString() ?: "null"
-                val flagStr = detail.featureFlag?.let {
-                    "on=${it.on} off=${it.offTreatment.wire} default=${it.defaultTreatment.wire} rules=${it.rules?.size ?: 0}"
-                } ?: "null"
-                Log.i(
+            // Diagnostic logging for entitlement decisions (FR-24821 triage). Gated behind
+            // BuildConfig.DEBUG and reduced to structural shape only — the full raw response
+            // body is never logged, as it carries sensitive entitlement data to device logs
+            // (FR-25935).
+            if (BuildConfig.DEBUG) {
+                Log.d(
                     TAG,
-                    "[ENT-DEBUG]   feature[$key]: planIds=$planIdsStr expireTime=$expireStr featureFlag=$flagStr linkedPermissions=${detail.linkedPermissions}"
+                    "[ENT-DEBUG] Parsed context — features: ${context.features.size}, plans: ${context.plans.size}, permissions: ${context.permissions.size}"
                 )
-            }
-            for ((key, plan) in context.plans) {
-                Log.i(
-                    TAG,
-                    "[ENT-DEBUG]   plan[$key]: defaultTreatment=${plan.defaultTreatment.wire} rules=${plan.rules?.size ?: 0}"
-                )
+                for ((key, detail) in context.features) {
+                    val planIdsStr = if (detail.planIds.isEmpty()) "[]" else "[${detail.planIds.joinToString(",")}]"
+                    val expireStr = detail.expireTime?.toString() ?: "null"
+                    val flagStr = detail.featureFlag?.let {
+                        "on=${it.on} off=${it.offTreatment.wire} default=${it.defaultTreatment.wire} rules=${it.rules?.size ?: 0}"
+                    } ?: "null"
+                    Log.d(
+                        TAG,
+                        "[ENT-DEBUG]   feature[$key]: planIds=$planIdsStr expireTime=$expireStr featureFlag=$flagStr linkedPermissions=${detail.linkedPermissions}"
+                    )
+                }
+                for ((key, plan) in context.plans) {
+                    Log.d(
+                        TAG,
+                        "[ENT-DEBUG]   plan[$key]: defaultTreatment=${plan.defaultTreatment.wire} rules=${plan.rules?.size ?: 0}"
+                    )
+                }
             }
 
             // Keep populating featureKeys/permissionKeys for backwards compat with

--- a/android/src/test/java/com/frontegg/android/embedded/FronteggNativeBridgeTest.kt
+++ b/android/src/test/java/com/frontegg/android/embedded/FronteggNativeBridgeTest.kt
@@ -1,0 +1,160 @@
+package com.frontegg.android.embedded
+
+import android.content.Context
+import android.util.Log
+import com.frontegg.android.FronteggApp
+import com.frontegg.android.services.CredentialManager
+import com.frontegg.android.services.FronteggAuthService
+import com.frontegg.android.services.FronteggInnerStorage
+import com.frontegg.android.services.FronteggState
+import com.frontegg.android.services.StorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * FR-25935: every @JavascriptInterface method on the bridge must be gated by the same
+ * same-origin check as getTokens. If the WebView is navigated/redirected to non-Frontegg
+ * content, that content must not be able to drive native SSO/social-login intents or flip
+ * the loader.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FronteggNativeBridgeTest {
+    private val baseUrl = "https://base.url.com"
+    private val trustedUrl = "https://base.url.com/oauth/account/login"
+    private val untrustedUrl = "https://evil.example.com/phish"
+
+    private val context = mockk<Context>()
+    private val webClient = mockk<FronteggWebClient>()
+    private val auth = mockk<FronteggAuthService>()
+    private val credentialManager = mockk<CredentialManager>()
+    private val storage = mockk<FronteggInnerStorage>()
+    private lateinit var bridge: FronteggNativeBridge
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>(), any()) } returns 0
+
+        every { context.startActivity(any()) } returns Unit
+
+        every { auth.baseUrl } returns baseUrl
+        every { auth.credentialManager } returns credentialManager
+        every { credentialManager.saveCodeVerifier(any()) } returns true
+
+        val app = mockk<FronteggApp>()
+        every { app.auth } returns auth
+        mockkObject(FronteggApp.Companion)
+        mockkObject(FronteggApp)
+        every { FronteggApp.instance } returns app
+
+        // AuthorizeUrlGenerator (built for real inside the login methods) only assembles a
+        // URL string — no network. Give it the storage it reads.
+        every { storage.clientId } returns "TestClientId"
+        every { storage.applicationId } returns null
+        every { storage.baseUrl } returns baseUrl
+        every { storage.packageName } returns "test.com"
+        every { storage.useAssetsLinks } returns false
+        mockkObject(StorageProvider)
+        every { StorageProvider.getInnerStorage() } returns storage
+
+        every { webClient.getFormAction() } returns "login"
+
+        bridge = FronteggNativeBridge(context, webClient)
+
+        FronteggState.webLoading.value = false
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun onTrustedOrigin() {
+        every { webClient.currentUrlMainSafe() } returns trustedUrl
+    }
+
+    private fun onUntrustedOrigin() {
+        every { webClient.currentUrlMainSafe() } returns untrustedUrl
+    }
+
+    @Test
+    fun `setLoading is refused from an untrusted origin`() {
+        onUntrustedOrigin()
+        FronteggState.webLoading.value = false
+
+        bridge.setLoading(true)
+
+        assert(!FronteggState.webLoading.value) { "setLoading must be ignored from an untrusted origin" }
+    }
+
+    @Test
+    fun `setLoading is applied from a trusted origin`() {
+        onTrustedOrigin()
+        FronteggState.webLoading.value = false
+
+        bridge.setLoading(true)
+
+        assert(FronteggState.webLoading.value) { "setLoading must work from a trusted origin" }
+    }
+
+    @Test
+    fun `loginWithSSO does not start an activity from an untrusted origin`() {
+        onUntrustedOrigin()
+
+        bridge.loginWithSSO("user@example.com")
+
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `loginWithSSO starts an activity from a trusted origin`() {
+        onTrustedOrigin()
+
+        bridge.loginWithSSO("user@example.com")
+
+        verify { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `loginWithSocialLogin does not start an activity from an untrusted origin`() {
+        onUntrustedOrigin()
+
+        bridge.loginWithSocialLogin("https://social.example.com/authorize")
+
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `loginWithCustomSocialLoginProvider does not start an activity from an untrusted origin`() {
+        onUntrustedOrigin()
+
+        bridge.loginWithCustomSocialLoginProvider("custom-provider")
+
+        verify(exactly = 0) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun `loginWithSocialLoginProvider does not read form action from an untrusted origin`() {
+        onUntrustedOrigin()
+
+        bridge.loginWithSocialLoginProvider("google")
+
+        // The guard sits above getFormAction(); on an untrusted origin the method returns
+        // before consulting the web client for the form action.
+        verify(exactly = 0) { webClient.getFormAction() }
+    }
+}


### PR DESCRIPTION
## Problem (FR-25935)

The new `getTokens` bridge validates the caller's origin via `isTrustedOrigin` (scheme+host+port), but the other `@JavascriptInterface` methods on `FronteggNativeBridge` — `loginWithSSO`, `loginWithSocialLogin`, `loginWithSocialLoginProvider`, `loginWithCustomSocialLoginProvider`, `setLoading` — had **no** origin check, and the bridge is injected for every page load (`FronteggWebView.kt:80`). If the WebView is ever navigated/redirected to non-Frontegg content, that content could trigger native SSO/social-login intents or flip the loader.

Separately, `Api.kt` logged the **full raw** `/user-entitlements` response body at `Log.i` unconditionally (`[ENT-DEBUG] RAW …`) plus per-feature/plan detail — sensitive data on device logs.

## Fix

- Add a shared `isFromTrustedOrigin(action)` same-origin gate (reusing the existing `isTrustedOrigin` helper) at the top of every bridge method. Content served from anywhere other than the Frontegg base URL is refused.
- Drop the raw-body dump entirely; gate the remaining **structural** entitlement diagnostics (counts, feature/plan shape — no values) behind `BuildConfig.DEBUG` at `Log.d`.

## Tests

New `FronteggNativeBridgeTest`:
- `setLoading` refused from an untrusted origin / applied from a trusted origin
- `loginWithSSO` starts an activity from a trusted origin but not from an untrusted one
- `loginWithSocialLogin` / `loginWithCustomSocialLoginProvider` don't start an activity from an untrusted origin
- `loginWithSocialLoginProvider` doesn't even read the form action from an untrusted origin

All untrusted-origin cases failed RED before the guard, pass after. Full `:android` unit-test suite green. (The logging change is compile-time gated on `BuildConfig.DEBUG`, so it isn't unit-tested.)