### PR TITLE
fix(embedded): persist auth-completion across recreation; guard user-cancel (FR-25934)

### DIFF
--- a/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
+++ b/android/src/main/java/com/frontegg/android/EmbeddedAuthActivity.kt
@@ -57,6 +57,7 @@ open class EmbeddedAuthActivity : FronteggBaseActivity() {
             directLoginLaunchedDone =
                 savedInstanceState.getBoolean(DIRECT_LOGIN_ACTION_LAUNCHED_DONE, false)
             webViewUrl = savedInstanceState.getString(BUNDLE_KEY_WEBVIEW_URL)
+            authCompleted = readAuthCompleted(savedInstanceState)
         } else {
             consumeIntent(intent)
         }
@@ -67,6 +68,7 @@ open class EmbeddedAuthActivity : FronteggBaseActivity() {
         outState.putBoolean(DIRECT_LOGIN_ACTION_LAUNCHED, this.directLoginLaunched)
         outState.putBoolean(DIRECT_LOGIN_ACTION_LAUNCHED_DONE, this.directLoginLaunchedDone)
         outState.putString(BUNDLE_KEY_WEBVIEW_URL, this.webViewUrl)
+        writeAuthCompleted(outState, this.authCompleted)
         webView.saveState(outState)
     }
 
@@ -389,8 +391,9 @@ open class EmbeddedAuthActivity : FronteggBaseActivity() {
         super.onDestroy()
         FronteggState.webLoading.value = false
         // Only treat as user-cancelled when the activity is truly finishing,
-        // not during configuration changes or system-driven recreation.
-        if (!authCompleted && isFinishing && !isChangingConfigurations) {
+        // not during configuration changes or system-driven recreation — and not when
+        // auth already completed (the flag is now persisted across recreation, FR-25934).
+        if (shouldDeliverUserCancellation(authCompleted, isFinishing, isChangingConfigurations)) {
             onAuthFinishedCallback?.invoke(CanceledByUserException())
             onAuthFinishedCallback = null
         }
@@ -405,8 +408,31 @@ open class EmbeddedAuthActivity : FronteggBaseActivity() {
         const val DIRECT_LOGIN_ACTION_DATA = "com.frontegg.android.DIRECT_LOGIN_ACTION_DATA"
         private const val BUNDLE_KEY_WEBVIEW_URL = "com.frontegg.android.WEBVIEW_URL"
         private const val AUTH_LAUNCHED = "com.frontegg.android.AUTH_LAUNCHED"
+        private const val BUNDLE_KEY_AUTH_COMPLETED = "com.frontegg.android.AUTH_COMPLETED"
         private val TAG = EmbeddedAuthActivity::class.java.simpleName
         var onAuthFinishedCallback: ((error: Exception?) -> Unit)? = null // Store callback
+
+        /**
+         * Whether [onDestroy] should report a user cancellation: only when the activity is
+         * truly finishing (not a configuration change / system recreation) and auth did not
+         * already complete. Extracted and unit-tested (FR-25934) so the persisted completion
+         * state is honoured after a process-death recreation instead of firing a spurious
+         * cancel with a reset `authCompleted`.
+         */
+        internal fun shouldDeliverUserCancellation(
+            authCompleted: Boolean,
+            isFinishing: Boolean,
+            isChangingConfigurations: Boolean
+        ): Boolean = !authCompleted && isFinishing && !isChangingConfigurations
+
+        /** Persists the auth-completion flag so it survives process death / recreation (FR-25934). */
+        internal fun writeAuthCompleted(outState: Bundle, authCompleted: Boolean) {
+            outState.putBoolean(BUNDLE_KEY_AUTH_COMPLETED, authCompleted)
+        }
+
+        /** Restores the flag saved by [writeAuthCompleted]; false when absent. */
+        internal fun readAuthCompleted(savedInstanceState: Bundle): Boolean =
+            savedInstanceState.getBoolean(BUNDLE_KEY_AUTH_COMPLETED, false)
 
         /**
          * Authenticates the user using the Frontegg embedded login experience.

--- a/android/src/test/java/com/frontegg/android/EmbeddedAuthActivityTest.kt
+++ b/android/src/test/java/com/frontegg/android/EmbeddedAuthActivityTest.kt
@@ -1,116 +1,80 @@
 package com.frontegg.android
 
-import android.app.Activity
-import android.content.Intent
-import com.frontegg.android.services.CredentialManager
-import com.frontegg.android.services.FronteggAuthService
-import com.frontegg.android.services.FronteggInnerStorage
-import com.frontegg.android.services.StorageProvider
-import io.mockk.CapturingSlot
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.unmockkAll
-import io.mockk.verify
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Before
+import android.os.Bundle
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Regression guard for FR-19725: the embedded-mode auth launches must use
- * [Activity.startActivity] (no request code), not the deprecated
- * `startActivityForResult`. The result was never consumed via `onActivityResult`,
- * so these tests lock in that each entry point still launches, targets
- * [EmbeddedAuthActivity], and no longer requests a result.
+ * FR-25934: the embedded auth flow used a static callback plus an un-persisted
+ * `authCompleted` flag. After process death the activity is recreated from
+ * savedInstanceState with `authCompleted` reset to false, which could fire a
+ * spurious user-cancellation. These cover the two contained fixes: persisting the
+ * completion flag, and the guard that decides whether onDestroy reports a cancel.
  */
 @RunWith(RobolectricTestRunner::class)
 class EmbeddedAuthActivityTest {
 
-    private lateinit var activity: Activity
-    private lateinit var intentSlot: CapturingSlot<Intent>
-
-    @Before
-    fun setUp() {
-        activity = mockk(relaxed = true)
-        intentSlot = slot()
-        every { activity.startActivity(capture(intentSlot)) } returns Unit
-
-        // The entry points build an authorize URL via `AuthorizeUrlGenerator(activity)`,
-        // whose constructor reads StorageProvider + `context.fronteggAuth`. Satisfy those
-        // so the real generator runs (deterministic; its only side effect lands on the
-        // relaxed CredentialManager mock).
-        val storage = mockk<FronteggInnerStorage>(relaxed = true)
-        every { storage.baseUrl } returns "https://base.url.com"
-        every { storage.clientId } returns "TestClientId"
-        every { storage.applicationId } returns "TestApplicationId"
-        mockkObject(StorageProvider)
-        every { StorageProvider.getInnerStorage() } returns storage
-
-        val authService = mockk<FronteggAuthService>(relaxed = true)
-        every { authService.credentialManager } returns mockk<CredentialManager>(relaxed = true)
-        mockkStatic("com.frontegg.android.FronteggAppKt")
-        every { activity.fronteggAuth } returns authService
-    }
-
-    @After
-    fun tearDown() {
-        EmbeddedAuthActivity.onAuthFinishedCallback = null
-        unmockkAll()
-    }
+    // --- user-cancellation guard ---
 
     @Test
-    fun `authenticate launches EmbeddedAuthActivity via startActivity without a request code`() {
-        EmbeddedAuthActivity.authenticate(activity)
-
-        verify(exactly = 1) { activity.startActivity(any()) }
-        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
-        assertEquals(
-            EmbeddedAuthActivity::class.java.name,
-            intentSlot.captured.component?.className
+    fun `delivers user cancellation when finishing, not completed, not a config change`() {
+        assertTrue(
+            EmbeddedAuthActivity.shouldDeliverUserCancellation(
+                authCompleted = false,
+                isFinishing = true,
+                isChangingConfigurations = false
+            )
         )
     }
 
     @Test
-    fun `directLoginAction launches EmbeddedAuthActivity via startActivity without a request code`() {
-        EmbeddedAuthActivity.directLoginAction(activity, "type", "data")
-
-        verify(exactly = 1) { activity.startActivity(any()) }
-        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
-        assertEquals(
-            EmbeddedAuthActivity::class.java.name,
-            intentSlot.captured.component?.className
+    fun `does not deliver cancellation when auth already completed`() {
+        assertFalse(
+            EmbeddedAuthActivity.shouldDeliverUserCancellation(
+                authCompleted = true,
+                isFinishing = true,
+                isChangingConfigurations = false
+            )
         )
     }
 
     @Test
-    fun `authenticateWithMultiFactor launches EmbeddedAuthActivity via startActivity without a request code`() {
-        EmbeddedAuthActivity.authenticateWithMultiFactor(activity, "mfaLoginAction")
-
-        verify(exactly = 1) { activity.startActivity(any()) }
-        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
-        assertEquals(
-            EmbeddedAuthActivity::class.java.name,
-            intentSlot.captured.component?.className
+    fun `does not deliver cancellation during a configuration change`() {
+        assertFalse(
+            EmbeddedAuthActivity.shouldDeliverUserCancellation(
+                authCompleted = false,
+                isFinishing = true,
+                isChangingConfigurations = true
+            )
         )
     }
 
     @Test
-    fun `authenticateWithStepUp launches StepUpAuthActivity via startActivity without a request code`() {
-        EmbeddedAuthActivity.authenticateWithStepUp(activity, null)
-
-        verify(exactly = 1) { activity.startActivity(any()) }
-        verify(exactly = 0) { activity.startActivityForResult(any(), any()) }
-        // Step-up launches StepUpAuthActivity — the always-enabled EmbeddedAuthActivity
-        // subclass — so it works in hosted-login apps where EmbeddedAuthActivity is
-        // disabled in the manifest (FR-24939).
-        assertEquals(
-            StepUpAuthActivity::class.java.name,
-            intentSlot.captured.component?.className
+    fun `does not deliver cancellation when not finishing`() {
+        assertFalse(
+            EmbeddedAuthActivity.shouldDeliverUserCancellation(
+                authCompleted = false,
+                isFinishing = false,
+                isChangingConfigurations = false
+            )
         )
+    }
+
+    // --- authCompleted persistence across process death ---
+
+    @Test
+    fun `authCompleted round-trips through the saved-state bundle`() {
+        val bundle = Bundle()
+        EmbeddedAuthActivity.writeAuthCompleted(bundle, true)
+
+        assertTrue(EmbeddedAuthActivity.readAuthCompleted(bundle))
+    }
+
+    @Test
+    fun `authCompleted defaults to false when absent from the bundle`() {
+        assertFalse(EmbeddedAuthActivity.readAuthCompleted(Bundle()))
     }
 }


### PR DESCRIPTION
## Problem (FR-25934)

`EmbeddedAuthActivity.onAuthFinishedCallback` is a static companion `var`, and `authCompleted` was a plain instance field **not** persisted in `onSaveInstanceState` (only the direct-login flags / webView state were). After process death the activity is recreated from `savedInstanceState` with `authCompleted` reset to `false`, so a finishing `onDestroy` could fire a spurious `CanceledByUserException` even though auth had completed before the process was killed.

## Fix (contained)

- Persist `authCompleted` in the saved-state bundle (`writeAuthCompleted`) and restore it in `onCreate` (`readAuthCompleted`).
- Route the `onDestroy` cancel decision through a small, unit-tested `shouldDeliverUserCancellation(authCompleted, isFinishing, isChangingConfigurations)` guard.

### Scope note
The static `onAuthFinishedCallback` is a **lambda held in the host app's memory** and genuinely cannot survive process death — it can't be restored from a `Bundle`. Fully re-delivering the login result across process death requires changing the **result-delivery contract** (`setResult`/`onActivityResult`, or having host apps observe the durable `FronteggState.isAuthenticated`). That's a host-app-facing change and is intentionally **out of scope** for this PR; this change removes the spurious-cancel / mis-sequencing surface without a contract change.

## Tests

New `EmbeddedAuthActivityTest` (pure companion functions, mirroring `AdminPortalActivityTest`):
- the cancel guard across all four `authCompleted` × `isFinishing` × `isChangingConfigurations` cases
- the `authCompleted` save/restore bundle round-trip + default-false

Full `:android` unit-test suite green.