### PR TITLE
fix(entitlements): stop a DNS failure crashing the host app (FR-26615)

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/Api.kt
+++ b/android/src/main/java/com/frontegg/android/services/Api.kt
@@ -308,7 +308,12 @@ open class Api(
 
     fun getUserEntitlements(accessTokenOverride: String? = null): EntitlementState? {
         val call = buildGetRequest(ApiConstants.userEntitlements, accessTokenOverride)
-        val response = call.execute()
+        val response = try {
+            call.execute()
+        } catch (e: IOException) {
+            Log.w(TAG, "getUserEntitlements failed: ${e.javaClass.simpleName}")
+            return null
+        }
         if (!response.isSuccessful) {
             Log.w(TAG, "getUserEntitlements failed: ${response.code}")
             return null

--- a/android/src/test/java/com/frontegg/android/services/EntitlementsNetworkFailureTest.kt
+++ b/android/src/test/java/com/frontegg/android/services/EntitlementsNetworkFailureTest.kt
@@ -1,0 +1,56 @@
+package com.frontegg.android.services
+
+import android.util.Log
+import com.frontegg.android.utils.CredentialKeys
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A DNS failure while loading entitlements must not escape as an exception.
+ * `.invalid` is reserved by RFC 2606 and never resolves, so `call.execute()`
+ * throws `UnknownHostException` without needing a network.
+ */
+class EntitlementsNetworkFailureTest {
+
+    private lateinit var api: Api
+    private lateinit var credentialManager: CredentialManager
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any(), any()) } returns 0
+
+        credentialManager = mockk(relaxed = true)
+        every { credentialManager.get(CredentialKeys.ACCESS_TOKEN) } returns "access-token"
+
+        val storage = mockk<FronteggInnerStorage>(relaxed = true)
+        every { storage.baseUrl } returns "https://frontegg-dns-failure.invalid"
+        every { storage.clientId } returns "client-id"
+        every { storage.applicationId } returns null
+        mockkObject(StorageProvider)
+        every { StorageProvider.getInnerStorage() } returns storage
+
+        api = Api(credentialManager)
+    }
+
+    @Test
+    fun `getUserEntitlements returns null when the host cannot be resolved`() {
+        assertNull(api.getUserEntitlements(accessTokenOverride = "access-token"))
+    }
+
+    @Test
+    fun `EntitlementsService load returns false when the host cannot be resolved`() {
+        val service = EntitlementsService(api = api, enabled = true)
+
+        assertFalse(service.load("access-token"))
+    }
+}


### PR DESCRIPTION
### A transient DNS failure could crash the host app

Loading entitlements issued a network call whose `IOException` was never caught. It travelled from `Api.getUserEntitlements` through `EntitlementsService.load` into a root coroutine, where nothing handles it — so a routine name-resolution failure terminated the app. The customer logged ~948 crashes across 390 users since July 9, 99% of them while the app was in the background.

The call now returns `null` on `IOException`, which is the contract callers already expect (`load` maps `null` to `false`) and matches iOS, which is unaffected.

**Scope:** one call site. I checked the other three unguarded `bgScope.launch` blocks that touch the network — `api.logout` catches internally, `setCredentials` wraps `api.me()`, and the refresh path is guarded — so entitlements was the only one missed. No blanket exception handler was added, since that would mask genuine failures elsewhere.

**Verified:** a new test drives the real `Api` against an unresolvable host (`.invalid`, RFC 2606) and reproduces `java.net.UnknownHostException` with no network. It fails before this change and passes after. Full suite: 642 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
