### PR TITLE
FR-26743 - Carry the base path into the OAuth callback

### DIFF
--- a/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
+++ b/android/src/main/java/com/frontegg/android/services/FronteggAuthService.kt
@@ -1827,12 +1827,12 @@ class FronteggAuthService(
                 return null
             }
             
-            // 2) Path: /oauth/account/redirect/android/{packageName}/{provider} or /android/oauth/callback
+            // 2) Path: /oauth/account/redirect/android/{packageName}/{provider} or
+            // /android/oauth/callback, either of which may sit behind the vendor's
+            // public path prefix when Frontegg is exposed under one.
             val packageName = storage.packageName
-            val expectedPrefix = "/oauth/account/redirect/android/"
-            val expectedPrefix2 = "/android/oauth/callback"
-            
-            if (!path.startsWith(expectedPrefix) && !path.startsWith(expectedPrefix2)) {
+
+            if (!Constants.isGeneratedCallbackPath(path, Constants.normalizedBasePath(baseUrl))) {
                 Log.e(TAG, "Invalid callback path: $path")
                 return null
             }
@@ -1996,6 +1996,10 @@ class FronteggAuthService(
     fun defaultRedirectUri(): String {
         val baseUrl = storage.baseUrl
         val packageName = storage.packageName
+        // Always the App-Link form, regardless of useAssetsLinks: social login
+        // appends /{provider} to this and needs an https URL the browser can follow,
+        // not a custom scheme. Built from the whole base URL, so a vendor's public
+        // path prefix is already carried through.
         val baseRedirectUri = "$baseUrl/oauth/account/redirect/android/$packageName"
         // Return raw; encoding is applied where used as query param
         return baseRedirectUri

--- a/android/src/main/java/com/frontegg/android/utils/Constants.kt
+++ b/android/src/main/java/com/frontegg/android/utils/Constants.kt
@@ -59,6 +59,38 @@ class Constants {
             return accountActionRoutes.any { url.contains(it) }
         }
 
+        /**
+         * The path component of the configured base URL, without a trailing slash.
+         *
+         * A vendor can expose Frontegg under a prefix on a shared domain, with an
+         * edge worker translating `api.example.com/fe-auth/oauth/...` onto the real
+         * Frontegg host. It serves the association files through the same prefix, so
+         * every callback it publishes carries the prefix and the SDK has to send
+         * that exact form.
+         */
+        fun normalizedBasePath(baseUrl: String): String {
+            val path = try {
+                URI(baseUrl).path.orEmpty()
+            } catch (_: Exception) {
+                ""
+            }
+            return path.trimEnd('/').takeIf { it != "/" }.orEmpty()
+        }
+
+        /**
+         * Whether a callback path is one the SDK generates, allowing for the vendor's
+         * public path prefix.
+         *
+         * The root form stays acceptable regardless: apps already in the field were
+         * issued it and their allow-list entries still carry it.
+         */
+        fun isGeneratedCallbackPath(path: String, basePath: String = ""): Boolean {
+            val suffixes = listOf(APP_LINK_CALLBACK_PATH, CUSTOM_SCHEME_CALLBACK_PATH)
+            val prefixes = if (basePath.isEmpty()) listOf("") else listOf(basePath, "")
+
+            return prefixes.any { prefix -> suffixes.any { path.startsWith("$prefix$it") } }
+        }
+
         fun oauthCallbackUrl(baseUrl: String): String {
             // Use java.net.URI so JVM unit tests work; android.net.Uri.parse is often null under stubs.
             val uri = try {
@@ -74,12 +106,16 @@ class Constants {
             val storage = StorageProvider.getInnerStorage()
             val packageName = storage.packageName
             val useAssetsLinks = storage.useAssetsLinks
+            val basePath = normalizedBasePath(baseUrl)
             return if (useAssetsLinks) {
-                "$scheme://$hostPart/oauth/account/redirect/android/$packageName"
+                "$scheme://$hostPart$basePath$APP_LINK_CALLBACK_PATH/$packageName"
             } else {
-                "$packageName://$hostPart/android/oauth/callback"
+                "$packageName://$hostPart$basePath$CUSTOM_SCHEME_CALLBACK_PATH"
             }
         }
+
+        const val APP_LINK_CALLBACK_PATH = "/oauth/account/redirect/android"
+        const val CUSTOM_SCHEME_CALLBACK_PATH = "/android/oauth/callback"
 
         fun socialLoginRedirectUrl(baseUrl: String): String {
             return "$baseUrl/oauth/account/social/success"

--- a/android/src/test/java/com/frontegg/android/utils/ConstantsBasePathTest.kt
+++ b/android/src/test/java/com/frontegg/android/utils/ConstantsBasePathTest.kt
@@ -1,0 +1,129 @@
+package com.frontegg.android.utils
+
+import com.frontegg.android.services.FronteggInnerStorage
+import com.frontegg.android.services.StorageProvider
+import io.mockk.every
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Coverage for OAuth callbacks on a base URL that carries a path (FR-26743).
+ *
+ * A vendor can expose Frontegg under a path prefix on a shared domain -- an edge
+ * worker translating `api.example.com/fe-auth/oauth/...` onto the real Frontegg
+ * host, rewriting the association files it serves so the published callback paths
+ * carry the prefix.
+ *
+ * `oauthCallbackUrl` rebuilt the URI from host and port only, so the prefix was
+ * dropped in both branches and the app sent a callback matching neither the
+ * vendor's assetlinks binding nor the allow-list entry derived from it. The
+ * redirect then dies in the browser on a path the shared domain does not route to
+ * Frontegg, after the user has already authenticated.
+ */
+class ConstantsBasePathTest {
+    private lateinit var mockStorage: FronteggInnerStorage
+
+    private val host = "api.example.com"
+    private val basePath = "/fe-auth"
+    private val prefixedBaseUrl = "https://$host$basePath"
+    private val packageName = "com.example.app"
+
+    @Before
+    fun setUp() {
+        mockStorage = mockkClass(FronteggInnerStorage::class)
+        mockkObject(StorageProvider)
+        every { StorageProvider.getInnerStorage() }.returns(mockStorage)
+        every { mockStorage.packageName }.returns(packageName)
+        every { mockStorage.baseUrl }.returns(prefixedBaseUrl)
+    }
+
+    @Test
+    fun `app link callback carries the base path when the base url has one`() {
+        every { mockStorage.useAssetsLinks }.returns(true)
+
+        assertEquals(
+            "https://$host$basePath/oauth/account/redirect/android/$packageName",
+            Constants.oauthCallbackUrl(prefixedBaseUrl)
+        )
+    }
+
+    @Test
+    fun `custom scheme callback carries the base path when the base url has one`() {
+        every { mockStorage.useAssetsLinks }.returns(false)
+
+        assertEquals(
+            "$packageName://$host$basePath/android/oauth/callback",
+            Constants.oauthCallbackUrl(prefixedBaseUrl)
+        )
+    }
+
+    @Test
+    fun `a base url without a path is unaffected`() {
+        every { mockStorage.useAssetsLinks }.returns(true)
+        every { mockStorage.baseUrl }.returns("https://$host")
+
+        assertEquals(
+            "https://$host/oauth/account/redirect/android/$packageName",
+            Constants.oauthCallbackUrl("https://$host")
+        )
+    }
+
+    @Test
+    fun `a trailing slash does not double up in the callback`() {
+        every { mockStorage.useAssetsLinks }.returns(true)
+
+        assertEquals(
+            "https://$host$basePath/oauth/account/redirect/android/$packageName",
+            Constants.oauthCallbackUrl("$prefixedBaseUrl/")
+        )
+    }
+
+    @Test
+    fun `a port is still preserved alongside the base path`() {
+        every { mockStorage.useAssetsLinks }.returns(true)
+
+        assertEquals(
+            "https://$host:8443$basePath/oauth/account/redirect/android/$packageName",
+            Constants.oauthCallbackUrl("https://$host:8443$basePath")
+        )
+    }
+
+    /**
+     * `defaultRedirectUri()` builds the social-login callback from the whole base
+     * URL, so it already carried the prefix while `oauthCallbackUrl` dropped it --
+     * the two disagreed for any vendor with a base path. They must line up now.
+     *
+     * They still differ deliberately when `useAssetsLinks` is off: social login
+     * always needs the App-Link form because it appends /{provider} and the browser
+     * has to follow it, so only the App-Link branch is comparable here.
+     */
+    @Test
+    fun `the app link callback agrees with the social login redirect uri`() {
+        every { mockStorage.useAssetsLinks }.returns(true)
+
+        val fromConstants = Constants.oauthCallbackUrl(prefixedBaseUrl)
+        val fromBaseUrl = "$prefixedBaseUrl/oauth/account/redirect/android/$packageName"
+
+        assertEquals(fromBaseUrl, fromConstants)
+    }
+
+    @Test
+    fun `the callback matcher accepts the prefixed app link path`() {
+        assertTrue(
+            "the SDK must recognise the callback it now generates",
+            Constants.isGeneratedCallbackPath("$basePath/oauth/account/redirect/android/$packageName", basePath)
+        )
+    }
+
+    @Test
+    fun `the callback matcher still accepts the root form`() {
+        assertTrue(
+            "callbacks issued before this fix must keep matching",
+            Constants.isGeneratedCallbackPath("/oauth/account/redirect/android/$packageName", basePath)
+        )
+    }
+}


### PR DESCRIPTION
Android counterpart to frontegg/frontegg-ios-swift#318 (merged).

## The bug

A vendor can expose Frontegg under a path prefix on a shared domain - an edge worker translating `api.example.com/fe-auth/oauth/...` onto the real Frontegg host. It serves the association files through the same prefix and rewrites their nested paths, so every callback it publishes carries the prefix.

`Constants.oauthCallbackUrl` rebuilt the URI from host and port and never read the path:

```kotlin
val hostPart = if (port != -1 && port != 80 && port != 443) "$host:$port" else host
return if (useAssetsLinks) {
    "$scheme://$hostPart/oauth/account/redirect/android/$packageName"   // prefix lost
} else {
    "$packageName://$hostPart/android/oauth/callback"                   // prefix lost
}
```

So the prefix was dropped in **both** branches - worse than iOS, where the custom-scheme branch was correct and only the App-Link one was wrong. Those vendors sent a callback matching neither their assetlinks binding nor the allow-list entry derived from it, and the redirect died in the browser on a path the shared domain doesn't route to Frontegg - *after* the user had already authenticated.

## The fix

Read the base path and carry it into both forms. The callback matcher tolerates it too and still accepts the root form, so callbacks issued before this keep matching.

**`defaultRedirectUri()` is left alone.** It already built from the whole base URL, so it already carried the prefix - the two constructions disagreed only because `oauthCallbackUrl` was wrong. It keeps its own construction because it always returns the App-Link form regardless of `useAssetsLinks`: social login appends `/{provider}` and needs an https URL the browser can follow. I first folded it into `oauthCallbackUrl` and the existing suite caught the regression.

## Testing

8 new tests in `ConstantsBasePathTest` covering both branches, no-base-path vendors, a trailing slash, a port alongside the prefix, and the matcher accepting both the prefixed and root forms.

Verified these actually catch the bug rather than describing current behaviour: with the fix reverted, **5 of the 8 fail**. Full suite **650 tests, 0 failures**.

## What this does *not* do

**Prefixed vendors still won't work end to end on Android.** Intent filters bind `android:host="${frontegg_domain}"` with a root `pathPrefix`, and `android:host` cannot carry a path - so the app has no filter matching its own published callback even though the SDK now sends the right URI.

Closing that needs a manifest placeholder for the prefix and a real device to validate, which is out of scope here and tracked on FR-26743. This PR removes one of the two blockers; it does not claim the flow works.

frontegg/oauth-service#848 (merged) already accepts the prefixed callback server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)